### PR TITLE
perf: reduce allocation churn in CFD3D hashing and the default-pipeline step loop

### DIFF
--- a/engine/artifact_io/cfd3d_io.cpp
+++ b/engine/artifact_io/cfd3d_io.cpp
@@ -264,6 +264,34 @@ void append_field(std::string& output, const Cfd3dField& field) {
     for (const double value : field.values()) append_double_le(output, value);
 }
 
+// Exact byte count append_field will add for this field, so callers can
+// reserve() the destination up front instead of growing it one push_back at
+// a time -- the field payload alone can run to hundreds of megabytes.
+std::uint64_t field_hash_byte_count(const Cfd3dField& field) {
+    return sizeof(std::uint64_t) + static_cast<std::uint64_t>(field.size()) * sizeof(double);
+}
+
+// Exact byte count result_hash's append_* calls will produce, so `bytes` can
+// be reserved once instead of growing by repeated doubling-and-copy while a
+// ~1 GiB buffer is built.
+std::uint64_t result_hash_byte_count(const Cfd3dResult& result,
+                                     const std::vector<Cfd3dSnapshot>& snapshots,
+                                     const std::string& case_json) {
+    std::uint64_t total = 0;
+    total += sizeof(std::uint64_t) + version::kCfd3dResultSchema.size();
+    total += sizeof(std::uint64_t) + version::kCfd3dFieldFormat.size();
+    total += sizeof(std::uint64_t) + case_json.size();
+    total += sizeof(std::uint64_t) + result.solver_version.size();
+    total += 4 * sizeof(double);  // elapsed_time_s, beverage_mass_kg, tds_fraction, extraction_yield_fraction
+    for (const Cfd3dField* field : result_fields(result)) total += field_hash_byte_count(*field);
+    total += static_cast<std::uint64_t>(result.samples.size()) * 10 * sizeof(double);
+    for (const Cfd3dSnapshot& snapshot : snapshots) {
+        total += sizeof(double);  // snapshot.time_s
+        for (const Cfd3dField* field : snapshot_fields(snapshot)) total += field_hash_byte_count(*field);
+    }
+    return total;
+}
+
 std::vector<std::uint8_t> field_bytes(const Cfd3dField& field) {
     std::vector<std::uint8_t> bytes;
     bytes.reserve(field.size() * sizeof(double));
@@ -562,10 +590,12 @@ std::string dump_case_json(const Cfd3dCase& cfd3d_case, int indent) {
 std::string result_hash(const Cfd3dCase& cfd3d_case, const Cfd3dResult& result,
                         const std::vector<Cfd3dSnapshot>& snapshots) {
     validate_snapshots(result.mesh, snapshots);
+    const std::string case_json = case_json_for_hash(cfd3d_case);
     std::string bytes;
+    bytes.reserve(result_hash_byte_count(result, snapshots, case_json));
     append_string(bytes, std::string(version::kCfd3dResultSchema));
     append_string(bytes, std::string(version::kCfd3dFieldFormat));
-    append_string(bytes, case_json_for_hash(cfd3d_case));
+    append_string(bytes, case_json);
     append_string(bytes, result.solver_version);
     append_double_le(bytes, result.elapsed_time_s);
     append_double_le(bytes, result.beverage_mass_kg);

--- a/engine/artifact_io/sha256.cpp
+++ b/engine/artifact_io/sha256.cpp
@@ -56,16 +56,32 @@ std::string sha256_hex(const std::string& bytes) {
     std::array<std::uint32_t, 8> h{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
                                    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
 
-    std::string padded = bytes;
-    const std::uint64_t bit_length = static_cast<std::uint64_t>(bytes.size()) * 8;
-    padded.push_back('\x80');
-    while (padded.size() % 64 != 56) padded.push_back('\0');
-    for (int i = 7; i >= 0; --i) {
-        padded.push_back(static_cast<char>((bit_length >> (i * 8)) & 0xff));
+    // `bytes` can be close to 1 GiB (a CFD3D field/result payload). Transform
+    // full blocks straight out of it rather than copying the whole thing into
+    // a padded buffer first: the message tail (< 64 bytes) plus the 0x80
+    // terminator, zero padding, and the 8-byte bit length always fit in two
+    // 64-byte blocks, built here without ever duplicating the input.
+    const auto* data = reinterpret_cast<const unsigned char*>(bytes.data());
+    const std::size_t size = bytes.size();
+    const std::uint64_t bit_length = static_cast<std::uint64_t>(size) * 8;
+
+    std::size_t offset = 0;
+    for (; offset + 64 <= size; offset += 64) {
+        transform(h, data + offset);
     }
 
-    for (std::size_t offset = 0; offset < padded.size(); offset += 64) {
-        transform(h, reinterpret_cast<const unsigned char*>(padded.data() + offset));
+    std::array<unsigned char, 128> tail{};
+    const std::size_t tail_len = size - offset;
+    std::memcpy(tail.data(), data + offset, tail_len);
+    std::size_t padded_len = tail_len;
+    tail[padded_len++] = 0x80;
+    while (padded_len % 64 != 56) tail[padded_len++] = 0;
+    for (int i = 7; i >= 0; --i) {
+        tail[padded_len++] = static_cast<unsigned char>((bit_length >> (i * 8)) & 0xff);
+    }
+
+    for (std::size_t block_offset = 0; block_offset < padded_len; block_offset += 64) {
+        transform(h, tail.data() + block_offset);
     }
 
     static constexpr char kHex[] = "0123456789abcdef";

--- a/engine/espresso_core/simulator.cpp
+++ b/engine/espresso_core/simulator.cpp
@@ -363,7 +363,7 @@ std::pair<Boundaries, std::vector<Derived>> evaluate_regions(
                        ? (d.viscosity_pa_s * d.geometry.depth_m) /
                              (d.flow.resistance_pa_s_m3 * region_area_m2)
                        : 0.0);
-        derived.push_back(d);
+        derived.push_back(std::move(d));
     }
     return {boundaries, derived};
 }
@@ -654,13 +654,22 @@ ShotResult Simulator::run(const Recipe& recipe, const ModelCoefficients& coeff,
             break;
         }
 
-        const std::vector<RegionState> states_before_step = regions;
+        // advance_regions sets shot.time_s to exactly (step + 1) * dt, so this
+        // step crosses next_sample_time_s iff the same comparison holds now,
+        // one dt early -- letting the (potentially large, per-cell) region
+        // snapshot be skipped on the steps that don't need it for
+        // interpolation below.
+        const bool crosses_sample_boundary =
+            next_sample_time_s <= regions.front().shot.time_s + dt + 1.0e-9;
+        const std::vector<RegionState> states_before_step =
+            crosses_sample_boundary ? regions : std::vector<RegionState>{};
         if (!advance_regions(regions, derived, boundaries, recipe, coeff, config, *water_, dt,
                              step, result, warn, diag, termination)) {
             break;
         }
 
-        while (next_sample_time_s <= regions.front().shot.time_s + 1.0e-9) {
+        while (crosses_sample_boundary &&
+              next_sample_time_s <= regions.front().shot.time_s + 1.0e-9) {
             std::vector<RegionState> sampled_regions;
             sampled_regions.reserve(regions.size());
             for (std::size_t i = 0; i < regions.size(); ++i) {


### PR DESCRIPTION
## Summary

Profiling captured three `sample` traces under `profiling/sample/` (default
pipeline `bench`, `cfd`, `cfd3d`) and found two distinct allocation-churn
problems, prioritized by measured impact. Both are fixed here as pure
performance changes — no observable output changes (hashes are bit-identical,
full test suite and the determinism check both pass).

### 1. CFD3D result/field hashing (`sha256.cpp`, `cfd3d_io.cpp`)
`sha256_hex` was 79% of a cfd3d run's sampled time and drove peak memory to
multiple GB: it copied the whole (up to ~1 GiB) byte string into `padded`,
then triggered a *second* full reallocation-copy just to append a few SHA-256
padding bytes with no spare capacity. `result_hash` built that giant string
via unreserved `push_back`, byte by byte.

Fixed: `sha256_hex` now transforms 64-byte blocks straight out of the input
with zero copies (only the final <128-byte tail is materialized in a stack
buffer); `result_hash` now reserves its destination buffer's exact size up
front.

**Measured** (nx=ny=nz=64 cfd3d run, git-stash A/B): peak memory footprint
2.83 GB → 1.44 GB (-49%), peak RSS 2.51 GB → 1.50 GB, wall time 18.0s → 15.8s,
**result_hash bit-identical** before/after.

### 2. Default-pipeline step loop (`simulator.cpp`)
Malloc/free-family symbols were >60% of bench samples, with `Derived`'s copy
constructor as the hottest leaf. `evaluate_regions()` filled a local `Derived`
(three `std::vector<double>` members) and then deep-copied it again via
`derived.push_back(d)` before discarding the original. Separately,
`Simulator::run()` deep-copied the full region state every step regardless of
whether it was needed.

Fixed: `push_back(std::move(d))`, and made the region snapshot conditional on
the step actually crossing a sample-interval boundary.

**Measured** (`espressolab_cli bench`, git-stash A/B, 3 trials each): median
shot time 2.46ms → 1.94ms (-21%), throughput 406 → 514 sims/sec (+27%),
instructions retired -23%.

## Verification
- Full Catch2 suite: 166 test cases / 18,215 assertions pass.
- `[cfd3d]`, `[cfd]`, `[performance]` tags pass individually.
- `scripts/demo.sh` determinism check passes (identical result hash).
- Before/after numbers above measured directly via `git stash`/rebuild A-B,
  not estimated.

Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
