### PR TITLE
docs: refresh docs for grind, parallel sweeps, and measured counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 EspressoLab is a local engineering workbench that simulates an espresso shot
 from controllable brew inputs. Deterministic C++20 simulation core, React/TypeScript
-dashboard, an interactive terminal UI (`espressolab_cli tui`), no AI, plus a
-separate experimental CFD solver. Neither the browser nor the TUI calculates a
+dashboard, an interactive terminal UI (`espressolab_cli tui`), no AI, plus
+separate experimental CFD solvers and a grind model. Neither the browser nor the TUI calculates a
 displayed quantity — both post/call into the same native workflows and render
 what the native solver returns, so the file-oriented CLI, the TUI, tests, and
 the dashboard produce byte-identical numbers for the same inputs.
@@ -41,7 +41,7 @@ A POSIX PTY smoke matrix for the TUI runs separately from `espressolab_tests`
 python3 tests/pty/tui_smoke.py [path/to/espressolab_cli]
 ```
 
-The current Catch2 suite passes 165 cases/18,213 assertions. The PTY script
+The current Catch2 suite passes 204 cases/20,364 assertions. The PTY script
 defines 14 checks but was not rerun for the measured-shot documentation refresh.
 Hosted macOS, Linux, and dashboard jobs passed at `736cef3`; later hardening
 through `94fbe7a` does not yet have equivalent hosted evidence.
@@ -132,18 +132,24 @@ espressolab_cli tui  ->  espressolab_cli_support (workflows.cpp, tui/tui_forms.c
 
 Keep a new concern in the lowest layer that can own it: physics in the model
 library/solver, serialization in `artifact_io`, request translation in the
-server, rendering-only behavior in `web/`. The CFD solvers are deliberately
-outside the default Level 1-3 request path. CFD3D has explicit REST routes and
-independent artifacts/schemas; neither CFD solver may become a hidden dependency
-of the default pipeline or change its artifacts/hashes.
+server, rendering-only behavior in `web/`. The CFD solvers and the grind model
+are deliberately outside the default Level 1-3 request path. CFD3D has explicit
+REST routes and independent artifacts/schemas; the grind model has neither a
+REST route nor any hash. None of the three may become a hidden dependency of
+the default pipeline or change its artifacts/hashes.
 
-Threads live in the server and the TUI, not the engine: `ExperimentRunner::run`
+Threads live in the applications, not the engine: `ExperimentRunner::run`
 takes a `(completed, total) -> bool` progress callback and stops when it
-returns false. That's the engine's whole involvement in background sweeps —
-the server (for REST) and `apps/espressolab_cli/tui` (for the interactive
-shell) each own their own worker thread, cancellation flag, and job registry,
-so the same runner and the same native solver/calibration APIs work unchanged
-in the CLI, the TUI, and in tests (no thread at all there). Native execution
+returns false. That's the engine's whole involvement in background sweeps.
+Exactly three places own threads — the server (for REST),
+`apps/espressolab_cli/tui` (for the interactive shell), and
+`apps/espressolab_cli/sweep_batch_runner.cpp` (the `sweep --workers` parallel
+path) — so the same runner and the same native solver/calibration APIs work
+unchanged in the CLI, the TUI, and in tests (no thread at all there).
+`sweep_batch_runner.cpp` is the only place sweep points run concurrently;
+`engine/experiment_runner/` stays single-threaded and shares the pure helpers
+in `experiment.hpp` with it, so both paths emit identical runs, order, and
+per-run hashes. Add a fourth thread owner in an application, never in `engine/`. Native execution
 stays thread-agnostic: cancellation and coarse progress are a
 `CancellationCallback`/status-callback pair (`include/espressolab/execution.hpp`)
 checked at safe solver, pressure-iteration, calibration, and sweep boundaries,
@@ -160,11 +166,11 @@ recipe, coefficient, configuration, and result hashes.
 | `engine/cfd/` | Separate Level 4 axisymmetric porous-media solver |
 | `engine/cfd3d/` | Separate Cartesian 3D porous-media solver and field storage |
 | `engine/artifact_io/` | JSON/CSV load and dump, canonical hashes, manifests, artifact files |
-| `engine/experiment_runner/` | Sweep axes, Cartesian execution, progress, aggregate export |
+| `engine/experiment_runner/` | Sweep axes, Cartesian execution, progress, aggregate export (single-threaded) |
 | `engine/calibration/` | Measured-shot loading, loss functions, fitting, validation reports |
 | `engine/reference_io/` | Read-only reference-shot catalogue loading |
-| `include/espressolab/` | Public C++ headers shared across targets, including `execution.hpp` (the cancellation/status contract) |
-| `apps/espressolab_cli/` | Argv parsing, `workflows.{hpp,cpp}` (shared CLI workflow services), file-oriented command output |
+| `include/espressolab/` | Public C++ headers shared across targets, including `execution.hpp` (the cancellation/status contract) and `ring_buffer.hpp` (the bounded queue behind parallel sweeps) |
+| `apps/espressolab_cli/` | Argv parsing, `workflows.{hpp,cpp}` (shared CLI workflow services), `sweep_batch_runner.{hpp,cpp}` (the parallel sweep path), file-oriented command output |
 | `apps/espressolab_cli/tui/` | Interactive terminal UI: `tui_forms.{hpp,cpp}` (terminal-independent navigation/forms) and `tui.cpp` (FTXUI rendering) |
 | `apps/espressolab_server/` | Local REST translation, measured-shot comparison, in-memory runs, background sweep/CFD3D jobs (cpp-httplib) |
 | `web/src/features/` | shot, sweeps, run comparison, measured-shot comparison, calibration notice |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ A baseline shot on an M-series laptop:
 ```
 
 `espressolab_cli bench` runs a 60-second shot at 100 Hz in **0.49 ms** median —
-about 2000 simulations per second, and 40x inside the 20 ms budget.
+about 2000 simulations per second, and 40x inside the 20 ms budget. Like the
+shot above, that is the M-series laptop; the millisecond figure is
+hardware-dependent, so run the command for your own host rather than treating
+it as a property of the solver. The budget check is the portable claim.
 
 ## What a grind sweep looks like
 
@@ -112,6 +115,9 @@ web (React/TS)  ->  tool_server (REST)  ->  experiment_runner
 
 CLI and CFD tests  ->  cfd / cfd3d (separate Level 4 solvers)
                                       -> espresso_core + model_library
+
+espressolab_cli grind  ->  grind (separate comminution model)
+                                      -> espressolab_core_types only
 ```
 
 Dependencies point inward. The simulation library knows nothing about HTTP,
@@ -140,7 +146,12 @@ What it does **not** do:
 - **Nothing is validated against a real shot**, CFD included. Verification and
   validation are different claims; see below.
 - No mapping from a grinder dial number to particle size. Grind is a physical
-  input in micrometres.
+  input in micrometres. A recipe may instead carry a particle size distribution
+  (`puck.grind`), from which the solver derives d32 and the spread and extracts
+  each size class at its own rate; `espressolab_cli grind` generates one from
+  burr geometry, but it too takes a physical gap in microns, not a dial number,
+  and sits outside the shot pipeline. Nothing here has been checked against a
+  measured grind.
 - **No flavour prediction.** Estimated TDS and extraction yield are engineering
   outputs. Taste depends on compound composition, roast, water chemistry,
   distribution and sensory context this model does not resolve.
@@ -203,6 +214,7 @@ a re-fit never silently changes what a past run meant.
 espressolab_cli simulate --recipe <file> [--coefficients <file>] [--out <dir>]
                          [--dt <s>] [--sample-interval <s>] [--quiet]
 espressolab_cli sweep    --spec <file> [--out <dir>] [--quiet]
+                         [--workers <n>] [--ring-capacity <n>]
 espressolab_cli calibrate --shots <dir> --fit <name,...> [--holdout <id,...>]
                            [--coefficients <file>] [--out <file>] [--report <file>]
                            [--leave-one-out]
@@ -215,6 +227,7 @@ espressolab_cli cfd3d    --recipe <file> [--coefficients <file>] [--out <dir>]
                          [--sample-interval <s>] [--snapshot-interval <s>]
                          [--material <file>] [--quiet]
 espressolab_cli cfd3d    --case <file> [--out <dir>] [--quiet]
+espressolab_cli grind    [--spec <file>] [--out <dir>]
 espressolab_cli bench    [--seconds <s>] [--repeats <n>]
 
 espressolab_cli params     # sweepable recipe parameters
@@ -223,7 +236,15 @@ espressolab_cli version
 espressolab_cli tui        # interactive terminal UI (POSIX TTY only)
 ```
 
-`espressolab_cli tui` is a guided, form-based frontend to every command above,
+`sweep --workers <n>` opts into a parallel batch runner; leaving it unset keeps
+the sequential path. It produces the same runs, in the same order, with the
+same per-run result hashes either way — `--workers` and `--ring-capacity` buy
+wall time, never a different answer. `grind` turns burr geometry into a
+particle size distribution and, like the CFD commands, sits outside the shot
+pipeline and writes its own files.
+
+`espressolab_cli tui` is a guided, form-based frontend to the commands above
+(all but `grind`, which is file-oriented only),
 for interactive macOS/Linux terminals. It calls the same native loaders,
 solvers, calibration APIs, and artifact writers directly -- not the CLI, not
 the REST server -- so it produces the same units, artifacts, and result
@@ -239,6 +260,7 @@ Artifacts land in the layout of section 10.4:
 outputs/shots/<run-id>/{recipe,coefficients,summary,manifest}.json + samples.csv
 outputs/sweeps/<sweep-id>/{sweep.json,runs.jsonl,aggregate.csv,manifest.json}
 <cfd3d-out-dir>/{case,summary,manifest,mesh,index}.json + samples.csv + fields.elf3d
+<grind-out-dir>/grind.json + recipe-grind.json   (no hashes; not a shot artifact)
 ```
 
 ## Tests
@@ -247,10 +269,13 @@ outputs/sweeps/<sweep-id>/{sweep.json,runs.jsonl,aggregate.csv,manifest.json}
 ./scripts/test.sh
 ```
 
-The current native suite passes 165 test cases and 18,213 assertions: unit tests
+The current native suite passes 204 test cases and 20,364 assertions: unit tests
 for every correlation, whole-shot
 integration tests, generated-input property tests, mass-balance invariants, a
-step-size convergence test, sweep progress and cancellation tests, parallel-region
+step-size convergence test, sweep progress and cancellation tests, parallel
+sweep tests requiring the `--workers` path to match the sequential path run for
+run and hash for hash, particle size distribution tests pinning the pre-PSD
+recipe and result hashes, grinder comminution tests, parallel-region
 balance and serialization tests, axial grid-refinement and wetting-front tests, CFD verification tests
 (divergence, exact solutions, mesh convergence, conservation),
 calibration recovery tests, deterministic leave-one-out validation tests,
@@ -279,7 +304,7 @@ and dashboard jobs at commit `736cef3`; current branch hardening through
 | [docs/testing.md](docs/testing.md) | What each test layer is for |
 | [docs/roadmap.md](docs/roadmap.md) | Status against the four-week plan, and what is not done |
 | [docs/current-state-and-gaps.md](docs/current-state-and-gaps.md) | Evidence-based implementation status and open gaps |
-| [schemas/](schemas/) | JSON Schema for recipes, coefficients, shot results, and CFD3D cases/results |
+| [schemas/](schemas/) | JSON Schema for recipes, coefficients, shot results, CFD3D cases/results, and grinder specs/results |
 
 ## Requirements
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,16 @@ side of the puck down to the basket, each entry reporting that cell's final
 `saturation`, `temperature_c`, `pore_tds_percent` and `extraction_yield_percent`.
 Samples and the CSV export stay aggregate at every cell count.
 
+Grind may be posted in either of two spellings, never both: the scalar pair
+`puck.particle_diameter_um` + `puck.particle_spread_factor`, or a distribution
+`puck.grind.bins`, an array of `{diameter_um, mass_fraction}` objects. A body
+carrying both is rejected with `CONFLICTING_FIELD`. When `grind` is present the
+loader derives the representative diameter (the bins' Sauter mean, d32) and the
+spread from it, and extraction runs per size class; the derived d32 must still
+land in 150-800 µm even though bin diameters may span 10-2000 µm. The response
+shape is unchanged either way — the distribution affects the numbers, not the
+result contract. `assets/recipes/psd-bimodal.json` is a postable example.
+
 ## Running a Cartesian 3D CFD case
 
 The 3D endpoint is an explicit Level 4b path and does not change the standard
@@ -204,6 +214,11 @@ same-origin proxy, and direct API clients are expected to run locally.
 `GET /api/v1/health` returns the sweepable parameter paths, and
 `espressolab_cli params` prints the same list. The CLI still runs sweeps
 synchronously: it has nothing to poll from.
+
+Each REST sweep job runs on one thread, through the sequential
+`ExperimentRunner`. The CLI's parallel batch path (`sweep --workers`) has no
+REST equivalent and no effect on this endpoint. Since both paths emit identical
+runs, order, and per-run result hashes, that is a throughput difference only.
 
 ## Error contract
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,9 @@ web (React/TS)  ->  tool_server (REST)  ->  experiment_runner
 CLI and CFD tests  ->  cfd (separate Level 4 axisymmetric solver) -> espresso_core + model_library
 CLI and REST tests ->  cfd3d (Level 4b Cartesian solver)          -> espresso_core + model_library
 
+espressolab_cli grind  ->  grind (separate comminution model)
+                                      -> espressolab_core_types only
+
 espressolab_cli tui  ->  espressolab_cli_support (workflows.cpp, tui/tui_forms.cpp)
                                                      |
                                     same call every legacy command_* handler makes
@@ -31,6 +34,7 @@ espressolab_cli tui  ->  espressolab_cli_support (workflows.cpp, tui/tui_forms.c
 | `espressolab_artifacts` | Versioned JSON/CSV load and dump, result hashes | Physics decisions |
 | `espressolab_experiments` | Sweeps, run schedules, aggregation, artifact naming | Chart rendering |
 | `espressolab_calibration` | Measured shots, the loss function, the fit | Anything the solver depends on |
+| `espressolab_grind` | Separate comminution model (burr geometry -> particle size distribution) and its own spec/result documents | Recipes, shot artifacts, the default pipeline, any result hash |
 | `espressolab_cfd` | Separate Level 4 axisymmetric pressure and transport solver | REST, dashboard, standard artifacts, default result hashes |
 | `espressolab_cfd3d` | Level 4b Cartesian 3D REV-scale pressure and transport solver | Default Level 1-3 path, equation ownership outside the solver |
 | `espressolab_references` | Published reference-shot metadata and partial-load reporting | Simulation, fitting, or validation decisions |
@@ -53,6 +57,13 @@ result hashes emitted by the default solver.
 dedicated REST endpoints invoke it explicitly. Its case, summary, snapshot
 fields, and `ELF3D-1` field artifacts are separate contracts and never alter
 the standard shot result or its hashes.
+
+`espressolab_grind` is isolated in the same way, and more strictly: it depends
+on `espressolab_core_types` alone, has no REST route at all, and its spec and
+result documents carry no recipe hash, no coefficient hash, and no result hash.
+It produces a distribution a recipe *may* be given by hand (`puck.grind`), which
+is the only coupling between the two, and it is a copy-paste boundary rather
+than a call: nothing in the shot pipeline invokes the grinder.
 
 `espressolab_cli tui` is an application-layer frontend: it calls
 `espressolab_cli_support` directly (native loaders, solvers, calibration APIs,
@@ -87,15 +98,34 @@ builds a circular Cartesian cut-cell mesh, runs the Level 4b solver, and emits
 `Cfd3dResult` plus optional time-indexed field snapshots.
 ```
 
-## Threads live in the server and the TUI, not the engine
+## Threads live in the applications, not the engine
 
 `ExperimentRunner::run` takes an optional `(completed, total) -> bool` callback:
 it reports progress through it and stops when it returns false. That is the
-whole of the engine's involvement in background sweeps. The server (for REST)
-and `apps/espressolab_cli/tui` (for the interactive shell) each own their own
-worker thread, cancellation flag and job registry, so the same runner still
-works unchanged in the CLI, the TUI, and in tests, where there is no thread at
-all.
+whole of the engine's involvement in background sweeps. Three application-layer
+places own threads, and no engine target owns any:
+
+| Owner | Thread it owns | Purpose |
+| --- | --- | --- |
+| `apps/espressolab_server/` | Job threads | Background REST sweeps and CFD3D runs |
+| `apps/espressolab_cli/tui/` | One worker thread | Keeps the render loop responsive during a job |
+| `apps/espressolab_cli/sweep_batch_runner.cpp` | A pool of worker threads | `sweep --workers`, the parallel batch path |
+
+The third is the newest and the easiest to misread. `sweep_batch_runner.cpp`
+is the only place in the codebase that runs sweep points concurrently;
+`engine/experiment_runner/` stays single-threaded and knows nothing about it.
+The two paths share the pure, stateless building blocks declared in
+`experiment.hpp` (`execute_sweep_point` and friends), which is what lets them
+produce byte-identical results: worker count and ring capacity change arrival
+order at the consumer, never a run's content or its final position in
+`result.runs`. A `BoundedRingBuffer`
+(`include/espressolab/ring_buffer.hpp`) decouples the producer threads from
+the consumer that aggregates them, so a slow consumer applies back-pressure
+instead of growing an unbounded queue. Leaving `--workers` unset keeps the
+sequential path exactly as it was.
+
+Because the engine owns no thread, the same runner still works unchanged in
+the CLI, the TUI, and in tests, where there is no thread at all.
 
 Native execution beyond sweeps is thread-agnostic the same way: `Simulator`,
 `CfdSolver`, `Cfd3dSolver`, and `calibration::fit`/`leave_one_out` each accept
@@ -121,15 +151,19 @@ engine/espresso_core/       solver, profiles, validation, domain types
 engine/model_library/       water properties, puck resistance, extraction kinetics
 engine/cfd/                 separate Level 4 axisymmetric CFD solver
 engine/cfd3d/               Level 4b Cartesian 3D CFD solver
+engine/grind/               separate comminution model and its own IO
 engine/artifact_io/         JSON/CSV, SHA-256, manifests, ELF3D fields
-engine/experiment_runner/   sweep axes, cartesian product, aggregation
+engine/experiment_runner/   sweep axes, cartesian product, aggregation (single-threaded)
 engine/reference_io/        reference-shot catalogue loader
-include/espressolab/        public headers
-apps/espressolab_cli/       simulate, sweep, params, version, calibrate, synthesize, bench, cfd, cfd3d
+include/espressolab/        public headers, execution.hpp, ring_buffer.hpp
+apps/espressolab_cli/       simulate, sweep, params, version, calibrate, synthesize,
+                            bench, cfd, cfd3d, grind; sweep_batch_runner.{hpp,cpp}
+                            is the parallel sweep path behind --workers
 apps/espressolab_cli/tui/   interactive terminal UI over the same shared workflow services
 apps/espressolab_server/    REST endpoints on cpp-httplib
 web/src/features/           shot, sweeps, comparison, calibration
-assets/                     recipes, coefficients, sweep specs, measured shots
-schemas/                    JSON Schema for recipe, coefficients, shot result, CFD3D cases/results
-tests/                      unit, integration, fixtures
+assets/                     recipes, coefficients, sweep specs, measured shots, grinder specs
+schemas/                    JSON Schema for recipe, coefficients, shot result, CFD3D cases/results,
+                            grinder specs/results
+tests/                      unit, integration, fixtures; pty/, server/, cli/, schemas/ run outside test.sh
 ```

--- a/docs/current-state-and-gaps.md
+++ b/docs/current-state-and-gaps.md
@@ -45,7 +45,7 @@ server is local and session-bound.
 | Simulation core | Deterministic C++20 shot solver with pressure and inlet-temperature profiles, wetting, thermal state, extraction, transport, termination, warnings, and mass-balance diagnostics | Implemented and locally tested |
 | Model fidelity | Level 1 lumped puck behavior, Level 2 lateral parallel regions, and Level 3 stacked axial finite-volume cells | Implemented |
 | CFD | Separate 2D axisymmetric and Cartesian 3D finite-volume solvers with pressure, saturation, enthalpy, and solute transport | Implemented as explicit CLI paths; 3D also has asynchronous REST status/snapshot routes; verified, not validated |
-| CLI | `simulate`, `sweep`, `calibrate`, `synthesize`, `cfd`, `cfd3d`, `bench`, `params`, `fit-params`, and `version` commands | Implemented |
+| CLI | `simulate`, `sweep`, `calibrate`, `synthesize`, `cfd`, `cfd3d`, `grind`, `bench`, `params`, `fit-params`, and `version` commands | Implemented |
 | Terminal UI | `espressolab_cli tui`: guided forms over every CLI command, calling the same shared workflow services as the file-oriented commands; cooperative cancellation; POSIX-only | Implemented; native logic is locally tested, while the current 14-check PTY script was not rerun for this refresh |
 | REST server | Local API for health, recipes, references, measured-shot catalogue/comparison, shots, asynchronous sweeps and CFD3D jobs, cancellation, status, snapshots, and CSV artifacts | Implemented |
 | Dashboard | Recipe controls, measured-shot comparison, draggable pressure and temperature profiles, synchronized charts, pinned runs, sweep heat maps, progress/cancellation, exports, diagnostics, and puck cross-section replay | Implemented; some literal browser interactions remain unverified |
@@ -65,9 +65,13 @@ web -> local REST server -> experiment runner -> simulation core
 
 The physics core does not know about HTTP, React, plotting, or filesystem
 locations. The dashboard renders authoritative values returned by the native
-solver rather than reimplementing the model in browser code. The server owns
-background sweep workers and cancellation, leaving the runner usable by the CLI
-and tests without threads.
+solver rather than reimplementing the model in browser code. Threads are owned
+by the applications, never the engine: the server's background sweep and CFD3D
+jobs, the TUI's worker thread, and the CLI's opt-in parallel sweep pool
+(`sweep --workers`) are the only three thread owners, leaving the runner usable
+by the CLI and tests without threads. The parallel sweep path is required by
+test to produce the same runs, order, and per-run result hashes as the
+sequential one.
 
 ### Model and Scientific Scope
 
@@ -91,7 +95,7 @@ TDS and extraction yield are engineering outputs, not taste predictions.
 
 The repository documents the following local checks:
 
-- `./scripts/test.sh` passes 165 Catch2 test cases and 18,213 assertions. It does
+- `./scripts/test.sh` passes 204 Catch2 test cases and 20,364 assertions. It does
   not run PTY, dashboard, demo, or warnings-as-errors checks.
 - The dashboard production build succeeds and reports the existing non-blocking
   583.67 kB minified JavaScript chunk warning.
@@ -102,13 +106,18 @@ The repository documents the following local checks:
   and repeated-run hash equality.
 - The baseline reaches 36 g in approximately 29.03 seconds with no clamps and
   near-machine-precision water and solids residuals.
-- A 60-second, 100 Hz benchmark records approximately 0.468 ms median runtime,
-  substantially inside the documented 20 ms budget.
+- A 60-second, 100 Hz benchmark records approximately 0.468 ms median runtime
+  on the development machine, substantially inside the documented 20 ms budget.
+  The millisecond figure is hardware-dependent (a container used for this
+  documentation pass reported 2.454 ms median, still passing); the budget
+  result, not the absolute number, is the portable claim.
 - Verification tests cover units, correlations, whole-shot behavior, generated
   inputs, invariants, convergence, sweeps, parallel regions, axial cells, CFD,
   calibration recovery, deterministic leave-one-out mechanics, native
-  cancellation checkpoints, measured-shot comparison, and the TUI's pure
-  (terminal-free) navigation, form, and shared-workflow logic.
+  cancellation checkpoints, measured-shot comparison, the particle size
+  distribution and grinder models, the parallel sweep path's agreement with the
+  sequential one, and the TUI's pure (terminal-free) navigation, form, and
+  shared-workflow logic.
 - A separate POSIX PTY script (`tests/pty/tui_smoke.py`) defines 14 checks for
   launch, resize, guided execution, long-form scrolling, Ctrl-C, terminal
   restoration, and non-TTY rejection. It is outside Catch2/`ctest` and was not
@@ -144,9 +153,9 @@ and output should be presented as a model result rather than a prediction.
 | Gap | Impact | Completion signal |
 | --- | --- | --- |
 | Current-branch hosted CI evidence is absent | Commit `736cef3` passed macOS/Linux/dashboard jobs, but later hardening through `94fbe7a` has only local evidence recorded here | Hosted workflow passes at the current branch head |
-| Full browser interaction pass is outstanding | API and served-page checks pass, but profile editing, pinned comparison overlays, synchronized chart behavior, and UI downloads have not all been exercised literally in a browser | A repeatable browser checklist is run and recorded |
+| Full browser interaction pass is outstanding | API and served-page checks pass, and a headless Chromium session at `4f6e51c` drove recipe load, a shot run, the cross-section/charts, and a 1600-point sweep for the README capture; profile editing by dragging, pinned comparison overlays, UI-initiated downloads, and accessibility have not been exercised literally in a browser | A repeatable browser checklist is run and recorded |
 | Dashboard has a non-blocking 583.67 kB minified JavaScript chunk warning | Does not block the MVP, but indicates a performance/packaging follow-up for a polished release | Chunk is reduced or the warning is explicitly accepted with measured load impact |
-| Portfolio packaging is unfinished | The project is not yet represented by a final demo video and evidence-based resume/project claims | Demo recording and portfolio copy use only verified benchmark and validation results |
+| Portfolio packaging is unfinished | A 60-second dashboard capture is now in the README; evidence-based resume/project claims are still unwritten | Portfolio copy uses only verified benchmark and validation results |
 
 ### Product and Operational Gaps
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,12 +10,14 @@ boundaries, reproducibility guarantees, or cross-language data contracts.
 | `engine/espresso_core/` | Domain types, validation, profiles, state stepping, termination, and invariants for the Level 1-3 solver |
 | `engine/model_library/` | Water properties, puck geometry and permeability, heat, and extraction correlations |
 | `engine/cfd/` | Separate Level 4 axisymmetric porous-media solver |
+| `engine/cfd3d/` | Separate Level 4b Cartesian 3D porous-media solver and field snapshots |
+| `engine/grind/` | Separate comminution model (burr geometry to particle size distribution) with its own IO |
 | `engine/artifact_io/` | JSON/CSV load and dump, canonical hashes, manifests, and artifact files |
-| `engine/experiment_runner/` | Sweep axes, Cartesian execution, progress, and aggregate export |
+| `engine/experiment_runner/` | Sweep axes, Cartesian execution, progress, and aggregate export (single-threaded) |
 | `engine/calibration/` | Measured-shot loading, loss functions, fitting, and validation reports |
 | `engine/reference_io/` | Read-only reference-shot catalogue loading |
-| `include/espressolab/` | Public C++ headers shared across targets, including the cancellation/status contract (`execution.hpp`) |
-| `apps/espressolab_cli/` | Argv parsing and `workflows.{hpp,cpp}`: shared CLI workflow services (load, validate, run, write artifacts) used by both the legacy commands and the TUI |
+| `include/espressolab/` | Public C++ headers shared across targets, including the cancellation/status contract (`execution.hpp`) and the bounded queue behind parallel sweeps (`ring_buffer.hpp`) |
+| `apps/espressolab_cli/` | Argv parsing and `workflows.{hpp,cpp}`: shared CLI workflow services (load, validate, run, write artifacts) used by both the legacy commands and the TUI; `sweep_batch_runner.{hpp,cpp}` owns the parallel sweep path |
 | `apps/espressolab_cli/tui/` | The interactive terminal UI: `tui_forms.{hpp,cpp}` (navigation/forms, no terminal dependency) and `tui.cpp` (FTXUI rendering and the worker thread) |
 | `apps/espressolab_server/` | Local REST translation, in-memory runs, and background sweep jobs |
 | `web/src/` | React controls and visualizations for server-provided results |
@@ -23,14 +25,17 @@ boundaries, reproducibility guarantees, or cross-language data contracts.
 | `schemas/` | Intended JSON exchange formats |
 | `tests/` | Unit, integration, property, convergence, and verification tests |
 | `tests/pty/` | POSIX PTY smoke matrix for the TUI, run separately from `ctest` |
+| `tests/server/`, `tests/cli/` | Black-box smoke scripts that start a real built binary; registered under `ctest -L server`, not in `test.sh` |
+| `tests/schemas/` | Schema-vs-loader contract check; needs `jsonschema`, run by hand |
 
 ## Dependency Rule
 
 Dependencies point inward. The model library and Level 1-3 core know nothing
-about HTTP, React, CSV, JSON files, or browser state. The server owns threads;
-the experiment runner receives progress through a callback and remains usable by
-the CLI and native tests, where it owns no threads. The dashboard renders native
-results rather than calculating model metrics.
+about HTTP, React, CSV, JSON files, or browser state. Threads are owned by the
+applications, never the engine: the experiment runner receives progress through
+a callback and remains usable by the CLI and native tests, where it owns no
+threads. The dashboard renders native results rather than calculating model
+metrics.
 
 The TUI follows the same rule from the other direction: it is an
 application-layer frontend that calls native loaders, solvers, calibration
@@ -43,14 +48,26 @@ terminal UI dependency at all, which is what makes it usable from
 cooperative cancellation and coarse status are a callback pair
 (`espressolab::CancellationCallback` in `execution.hpp`), checked at solver,
 pressure-iteration, calibration, and sweep boundaries, not a thread the solver
-owns. Only the TUI's own worker thread (in `tui.cpp`) and the server's job
-threads exist; both call the same synchronous, thread-agnostic native APIs.
+owns. Exactly three thread owners exist -- the server's job threads, the TUI's
+worker thread (in `tui.cpp`), and the parallel sweep pool in
+`sweep_batch_runner.cpp` -- and all three call the same synchronous,
+thread-agnostic native APIs. If you add a fourth, it belongs in an application,
+not in `engine/`.
+
+`sweep_batch_runner.cpp` deserves its own note, because it is the one place
+where two execution paths must agree. It runs sweep points concurrently while
+`engine/experiment_runner/` stays sequential, and both call the same pure
+helpers from `experiment.hpp`, so a spec run with `--workers 8` must yield the
+same runs, in the same order, with the same per-run result hashes as the
+sequential path. Changing either path without the other is a determinism bug;
+`tests/integration/test_sweep_batch_runner.cpp` is what catches it.
 
 Keep a new concern in the lowest layer that can own it. A physics decision
 belongs in the model library or solver, serialization in `artifact_io`, request
 translation in the server, and rendering-only behavior in `web/` or `tui.cpp`.
-The separate CFD target may depend on the core and model library but must not
-become a hidden dependency of the default simulation pipeline.
+The separate CFD targets may depend on the core and model library, and the
+grind target on the core types, but none of them may become a hidden dependency
+of the default simulation pipeline or change its artifacts or hashes.
 
 For the component diagram and runtime flow, see [architecture.md](architecture.md).
 
@@ -102,8 +119,10 @@ tag or list available tests with:
 ```
 
 Native tests cover unit behavior, whole shots, invariants, axial cells,
-calibration, sweeps, CFD verification, cancellation checkpoints (`[cancellation]`),
-and the TUI's pure navigation/form/workflow logic (`[tui]`, `[cli_workflows]`)
+calibration, sweeps (sequential and parallel), CFD verification, the particle
+size distribution and grinder models (`[grind]`, `[grind_sim]`), cancellation
+checkpoints (`[cancellation]`), and the TUI's pure navigation/form/workflow
+logic (`[tui]`, `[cli_workflows]`)
 without a terminal. The web project currently has typechecking and build
 checks but no browser interaction test harness. Test a dashboard interaction
 manually through `./scripts/dev.sh` whenever changing dragging, selection,
@@ -127,8 +146,9 @@ matches real espresso; real-shot validation remains a separate evidence task.
 
 ## Changing a Data Contract
 
-Recipe, coefficient, result, sweep, and reference data cross several layers.
-Make those edits atomically and do not treat a schema edit as sufficient.
+Recipe, coefficient, result, sweep, measured-shot, CFD3D, grinder, and
+reference data cross several layers. Make those edits atomically and do not
+treat a schema edit as sufficient.
 
 1. Define the field, units, ownership, default behavior, and version impact in
    the C++ domain type.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,12 +98,48 @@ direct API use, see [api.md](api.md).
   --spec assets/sweeps/grind-size.json
 ```
 
-The CLI also exposes `calibrate`, `synthesize`, `bench`, and separate `cfd`
-and `cfd3d` commands. The default `simulate` pipeline is the Level 1-3 model
-used by the REST server and dashboard. `cfd`/`cfd3d` are experimental,
+The CLI also exposes `calibrate`, `synthesize`, `bench`, separate `cfd` and
+`cfd3d` commands, and `grind`. The default `simulate` pipeline is the Level 1-3
+model used by the REST server and dashboard. `cfd`/`cfd3d` are experimental,
 separate solvers; neither alters dashboard results, standard artifacts, or
 their hashes. See [model.md](model.md) before interpreting either solver as a
 real-world prediction.
+
+A large sweep can use more than one core:
+
+```bash
+./build/apps/espressolab_cli/espressolab_cli sweep \
+  --spec assets/sweeps/grind-size.json --workers 8
+```
+
+`--workers` opts into the parallel batch runner; without it the sweep runs
+sequentially exactly as before. `--ring-capacity <n>` overrides the default
+`workers * 4` bound on how many finished runs may queue up ahead of the
+aggregating consumer, and requires `--workers` to be set too.
+`ESPRESSOLAB_SWEEP_WORKERS` and `ESPRESSOLAB_SWEEP_RING_CAPACITY` are the same
+two overrides as environment variables, for benchmarking without editing a
+command line; a flag wins over its variable. Neither setting changes results:
+the parallel path produces the same runs, in the same order, with the same
+per-run result hashes as the sequential one.
+
+### Generate a grind distribution
+
+`espressolab_cli grind` turns burr geometry into a particle size distribution.
+It sits outside the shot pipeline, like the CFD solvers, and writes its own
+files rather than shot artifacts:
+
+```bash
+./build/apps/espressolab_cli/espressolab_cli grind \
+  --spec assets/grinders/burr-baseline.json --out outputs/grinds/baseline
+```
+
+The `recipe-grind.json` it writes is exactly the shape a recipe's `puck.grind`
+takes, so it pastes across unchanged. A recipe spells grind *either* as the
+scalar `particle_diameter_um` + `particle_spread_factor` pair *or* as a
+distribution, never both. Note that a spec which validates can still produce a
+distribution a recipe rejects: the recipe requires a derived d32 between 150
+and 800 µm, and a fine enough burr gap falls below that. Nothing in the grind
+model has been checked against a measured grind.
 
 ## Use the Interactive Terminal UI
 
@@ -111,8 +147,9 @@ real-world prediction.
 ./build/apps/espressolab_cli/espressolab_cli tui
 ```
 
-This launches a guided, form-based frontend to every command above, on an
-interactive macOS or Linux terminal. It calls the same native loaders,
+This launches a guided, form-based frontend to the command set above, on an
+interactive macOS or Linux terminal. It covers ten commands; `grind` is
+currently file-oriented only and has no TUI form. It calls the same native loaders,
 solvers, calibration APIs, and artifact writers as the file-oriented commands
 -- not the REST server, and not the CLI itself -- so it produces the same
 units, artifacts, and result hashes for the same inputs.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,11 +18,11 @@ latest hardening commits.
 | 1 | Skeleton, domain types, profiles, units, water properties, flow-only CLI | Complete | Core/model targets, unit tests, and CLI are present. |
 | 2 | Thermal state, wetting, extraction, mass balances, artifacts, determinism | Complete | Integration, invariant, convergence, and artifact tests pass. |
 | 3 | Sweep runner, REST server, React controls, synchronized charts, exports | Complete | Server routes, dashboard source, background sweeps, and production web build are present. |
-| 4 | Calibration, edge cases, CI, README, profiling, demo, portfolio packaging | Partial | Calibration and measured-shot comparison tooling, edge-case tests, documentation, benchmark, CLI demo, and hosted macOS/Linux/dashboard evidence at `736cef3` are complete; real calibration, current-head hosted evidence, demo video, and measured portfolio claims remain. |
+| 4 | Calibration, edge cases, CI, README, profiling, demo, portfolio packaging | Partial | Calibration and measured-shot comparison tooling, edge-case tests, documentation, benchmark, CLI demo, the recorded dashboard capture, and hosted macOS/Linux/dashboard evidence at `736cef3` are complete; real calibration, current-head hosted evidence, and measured portfolio claims remain. |
 
 ## Verified Locally
 
-- `./scripts/test.sh` passes: 165 Catch2 test cases and 18,213 assertions.
+- `./scripts/test.sh` passes: 204 Catch2 test cases and 20,364 assertions.
 - `npm --prefix web run build` succeeds. Vite reports a non-blocking 583.67 kB
   minified JavaScript chunk-size warning.
 - Hosted GitHub Actions macOS, Linux, and dashboard jobs passed at commit
@@ -35,7 +35,12 @@ latest hardening commits.
   Through that path, shot execution, shot CSV export, completed sweep CSV export,
   and cancelled-sweep partial CSV export all succeed.
 - `espressolab_cli bench` records a 60-second, 100 Hz shot in 0.468 ms median,
-  42.7x inside the guide's 20 ms performance budget.
+  42.7x inside the guide's 20 ms performance budget, on the development machine.
+  The absolute figure is hardware-dependent and should be re-measured per host
+  rather than quoted as a property of the solver: the same command in a
+  container for this documentation pass reported 2.454 ms median (8.1x
+  headroom), still passing. The budget check, not the millisecond count, is the
+  portable claim.
 - The baseline run reaches the 36 g target in 29.03 s with no clamps and closes
   water and solids residuals near machine precision.
 
@@ -49,7 +54,7 @@ latest hardening commits.
 | Export JSON and CSV artifacts | Verified locally | The demo writes shot and sweep artifacts. |
 | Reproduce the same result hash | Verified locally | The demo reports matching SHA-256 hashes. |
 | Pass conservation and convergence tests | Verified locally | Covered by the passing test suite. |
-| Run and compare shots in the browser | Partially verified | The Vite page, API proxy, shot flow, completed sweep, cancellation, and exports pass; literal browser interactions, including profile editing and pinned comparison overlays, remain unverified. |
+| Run and compare shots in the browser | Partially verified | The Vite page, API proxy, shot flow, completed sweep, cancellation, and exports pass. A headless Chromium (Playwright) session at `4f6e51c` drove the real dashboard for the README capture: loading the baseline recipe, running it, watching the cross-section and charts, and running a 1600-point sweep to a heat map. Profile editing by dragging, pinned comparison overlays, downloads triggered from the UI, and accessibility remain unverified. |
 | Clean-clone macOS and Linux verification | Verified at `736cef3`; current head pending | Hosted macOS, Linux, and dashboard jobs passed at `736cef3`; do not extend that evidence to hardening through `94fbe7a` until another run passes. |
 
 ## Completed Week 4 Tooling
@@ -71,7 +76,18 @@ latest hardening commits.
   implemented separately from standard shot artifacts.
 - **Experiment tooling.** The dashboard provides two-dimensional heat maps,
   background sweep jobs with progress and cancellation, and draggable pressure
-  and temperature profiles backed by numeric point lists.
+  and temperature profiles backed by numeric point lists. `sweep --workers`
+  adds an opt-in parallel batch runner with a tunable bounded ring buffer,
+  tested to produce the same runs, order, and per-run result hashes as the
+  sequential path.
+- **Particle size distribution and grind model.** A recipe may carry a
+  distribution (`puck.grind`) instead of the scalar diameter/spread pair; the
+  solver derives d32 and the spread from it and extracts each size class at its
+  own rate, with the pre-distribution recipe and result hashes pinned by test so
+  the addition changed no existing run. `espressolab_cli grind` generates such a
+  distribution from burr geometry. It has its own schemas and documents, carries
+  no hashes, and sits outside the shot pipeline; nothing in it has been checked
+  against a measured grind.
 - **Documentation and profiling.** The README, model, architecture, API,
   testing, and calibration documentation are present; the benchmark command is
   implemented.
@@ -86,11 +102,16 @@ latest hardening commits.
 - **Confirm current-head hosted CI.** The committed workflow passed on macOS,
   Linux, and the dashboard at `736cef3`. Run it again for hardening through
   `94fbe7a`; the older result is not evidence for those later commits.
-- **Run a browser interaction check.** The served page and API workflow are
-  verified. Use a controllable browser to edit a recipe and profile, pin runs for
-  comparison, inspect synchronized charts, and confirm downloads from the UI.
-- **Finish portfolio packaging.** Record the demo video and write resume bullets
-  from the verified benchmark and, after calibration, measured validation data.
+- **Finish the browser interaction check.** The served page and API workflow are
+  verified, and the README capture at `4f6e51c` drove the real dashboard through
+  headless Chromium for recipe load, a shot run, the cross-section and charts,
+  and a 1600-point sweep to a heat map. What a controllable browser still has to
+  cover: editing a profile by dragging its points, pinning runs for comparison
+  and inspecting the overlay, confirming downloads initiated from the UI, and an
+  accessibility pass.
+- **Finish portfolio packaging.** The 60-second dashboard capture in the README
+  covers the demo recording. Resume bullets from the verified benchmark and,
+  after calibration, measured validation data remain to be written.
 - **Calibration dashboard view.** The dashboard now compares measured telemetry
   against fixed coefficients, but fitting remains a CLI workflow. Do not call
   comparison calibration.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ Tags: `[unit]` `[units]` `[profile]` `[water]` `[permeability]` `[flow]` `[heat]
 `[extraction]` `[artifacts]` `[integration]` `[invariants]` `[convergence]`
 `[sweep]` `[calibration]` `[recovery]` `[property]` `[performance]` `[regions]`
 `[axial]` `[cfd]` `[cfd3d]` `[verification]` `[references]` `[progress]`
-`[cancellation]` `[tui]` `[cli_workflows]`.
+`[cancellation]` `[tui]` `[cli_workflows]` `[grind]` `[grind_sim]`.
 
 ```bash
 python3 tests/pty/tui_smoke.py    # separate POSIX PTY smoke matrix for the TUI
@@ -19,7 +19,7 @@ ctest --test-dir build -L server  # black-box REST/CLI smoke scripts, registered
 
 `./scripts/test.sh` does not run the PTY script, the `server`-labeled ctest
 smoke scripts, dashboard checks, demo, or warnings-as-errors build. The
-current Catch2 run passes 165 test cases and 18,213 assertions. The PTY
+current Catch2 run passes 204 test cases and 20,364 assertions. The PTY
 script currently defines 14 checks, but it was not rerun for this
 documentation refresh.
 
@@ -64,6 +64,48 @@ concentration has to rise and local yield has to fall with depth, which is the
 mechanism the lumped puck could not express; the balances have to close at 1, 3,
 8 and 32 cells; and the per-cell summary has to reach the serialized artifacts
 in screen-to-basket order.
+
+**Particle size distribution tests** (`[grind]`) guard the second grind
+spelling against the first. The load-bearing pair is the two "scalar recipes
+keep their pre-PSD hashes" cases: a recipe written with
+`particle_diameter_um`/`particle_spread_factor` has to produce the same recipe
+hash and the same result hash it produced before the distribution path
+existed, which is what makes `puck.grind` an addition rather than a silent
+contract change. Beyond that: a single-bin distribution has to reproduce the
+scalar shot exactly, d32 has to match the hand-computed harmonic form and get
+dragged down by a small mass of fines, permeability at d32 has to equal the
+scalar call, a size-resolved shot has to close its mass balances, and a
+distribution has to extract *less* than its own d32 would, because fines
+deplete first. The serialization cases pin the fixed point (load → dump →
+load → dump is exact), the mutual exclusion of the two spellings
+(`CONFLICTING_FIELD`), and the sweep behaviour: sweeping grind size rescales
+every bin, while sweeping the spread of a distribution is refused rather than
+guessed.
+
+**Grinder tests** (`[grind_sim]`) cover the comminution model behind
+`espressolab_cli grind`, which is outside the shot pipeline and owns no result
+hash. Breakage has to conserve mass exactly; the emitted distribution has to be
+one a recipe can actually carry; a finer burr gap has to give a finer grind and
+more passes a finer one still, with diminishing return; the distribution has to
+be bimodal rather than merely broad, since the fines peak is the whole point;
+and the same spec always has to give the same distribution. A round-trip case
+pastes a generated distribution into a recipe and runs it, which is the only
+place the grinder and the solver meet.
+
+**Parallel sweep tests** (`[sweep]`, plus `[unit]` ring-buffer tests) exist
+because `espressolab_cli sweep --workers` added a second execution path, and
+two paths that disagree are worse than one slow one. The load-bearing case
+requires the parallel batch runner to produce the same runs, in the same
+order, with the same per-run result hashes as `ExperimentRunner::run` for the
+same spec — concurrency may change arrival order at the consumer, never a
+run's content or its final position. A ring smaller than the worker count
+still has to deliver every run in order (the back-pressure path), cancellation
+has to leave an unbroken index prefix rather than a hole, an out-of-range
+corner has to be recorded rather than thrown, and an invalid spec has to be
+rejected before any worker thread starts. The `BoundedRingBuffer` underneath
+is tested separately: zero capacity is rejected, capacity actually bounds what
+is pending, multiple producers and one consumer see every value exactly once,
+and `pop` returns false only once the buffer is closed *and* drained.
 
 **CFD verification tests** are a different kind of test from everything else
 here, and the distinction matters. They do not ask whether the solver describes


### PR DESCRIPTION
The docs last tracked the code at 08-27; three feature commits landed
after that (the PSD recipe path, the comminution model, and the parallel
sweep batch runner) and left several documents describing a codebase that
no longer exists.

Corrected against the code and the built binaries:

- Test counts were 165 cases/18,213 assertions in five files; the suite
  actually passes 204 cases/20,364 assertions. Verified by running it.
- `[grind]` and `[grind_sim]` were missing from testing.md's tag list.
- `espressolab_cli grind` was absent from the README CLI block, the
  getting-started tour, both repository maps, and both architecture
  diagrams, though data-contracts.md and model.md already covered it.
- `sweep --workers`/`--ring-capacity` and their env vars were documented
  nowhere at all.
- The thread-ownership rule was stated as "threads live in the server and
  the TUI" and "only the TUI's worker thread and the server's job threads
  exist". sweep_batch_runner.cpp is a third owner, so the rule is now
  "threads live in the applications, not the engine", with the three
  owners named and the sequential/parallel equivalence spelled out.
- development.md's repository map was missing engine/cfd3d/ and
  engine/grind/; architecture.md's was missing engine/grind/.
- api.md documented the other optional recipe fields but not
  `puck.grind`, which crosses the REST boundary. Confirmed a PSD recipe
  POSTs successfully before documenting it, and noted that REST sweeps
  use the sequential runner only.
- roadmap.md/current-state-and-gaps.md listed the demo recording and the
  browser interaction pass as wholly outstanding; the README capture at
  4f6e51c drove the real dashboard through headless Chromium. Narrowed
  to what a browser still has not exercised rather than marking done.

Benchmark figures are left as recorded but marked hardware-dependent:
this container reports 2.454 ms median against the documented 0.468 ms,
so the 20 ms budget result is the portable claim, not the millisecond
count.

Claims verified by running them: the suite, scripts/demo.sh hash
equality, sequential vs `--workers 4 --ring-capacity 2` producing
identical runs.jsonl and aggregate.csv, the --ring-capacity/--workers
usage error, CONFLICTING_FIELD on both grind spellings, grind's
out-of-range d32 notice, and the grind output filenames.

Documentation only; no code changed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GdXs2FC3oEJXmW5XRSia7i