### PR TITLE
docs: note grinder bin-cap rejection mode for wide burr gaps

### DIFF
--- a/docs/current-state-and-gaps.md
+++ b/docs/current-state-and-gaps.md
@@ -194,6 +194,19 @@ project can support:
   deterministic, but its coefficients are a plausible baseline rather than a fit,
   and no distribution it produces has been compared against a measured one. It
   sits outside the shot pipeline and has no REST or dashboard surface.
+- A wide burr gap can be grinder-valid (`burr_gap_um` within its documented
+  50–1500 µm range) yet produce a distribution the recipe schema rejects, even
+  when its d32 sits well inside the shot model's supported 150–800 µm band. The
+  output grid always ends exactly at `bean_diameter_um`, so at the shipped
+  default (6000 µm) gaps above roughly 750–800 µm place a tail bin over the
+  recipe's 2000 µm per-bin cap — sometimes carrying a fraction of a percent of
+  total mass — and the whole distribution is rejected. Neither raising `bins`
+  nor `bean_diameter_um` recovers usability (both push the same or more mass
+  further past the cap); only shrinking `bean_diameter_um` toward the schema's
+  2000 µm floor does, which is a workaround, not a physically faithful whole
+  bean size. See `docs/model.md`'s grinder section. Not yet triaged: whether
+  the fix belongs in the grinder model (e.g. dropping negligible-mass tail
+  bins before validation) or is accepted as an input-space boundary.
 - Extraction and TDS do not predict flavor or sensory quality. The sensory
   overlay is a separate, deliberately non-authoritative layer: its solute-class
   shares, relative rates and axis weights are authored priors, none has been

--- a/docs/model.md
+++ b/docs/model.md
@@ -209,6 +209,25 @@ free to describe a bed the shot correlations do not cover — a fine enough gap
 yields a d32 below the supported 150–800 µm band, and a recipe carrying it is
 rejected. The CLI says so rather than letting it fail later.
 
+A wide burr gap can be rejected for a second, unrelated reason even when its
+d32 lands well inside the supported band: the output grid is 24 (by default)
+bins log-spaced between `fines_diameter_um` and `bean_diameter_um` inclusive,
+so `bean_diameter_um` is always the top grid point and every bin below it
+shifts higher as the gap widens. A recipe's `puck.grind` bins are capped at
+2000 µm each (see above), and with the shipped default `bean_diameter_um =
+6000`, gaps above roughly 750–800 µm start placing a tail bin over that cap —
+even one carrying a fraction of a percent of mass fails the whole
+distribution, since bin-range validation does not treat negligible-mass bins
+differently. This eats a large share of `burr_gap_um`'s own documented 50–1500
+µm range: at default settings, most gaps from ~800 µm up are grinder-valid but
+recipe-unusable. Neither `bins` nor `bean_diameter_um` fixes this by loosening
+it — more bins only adds resolution within the same fines-to-bean span
+(usually surfacing *more* violating bins, not fewer), and a larger
+`bean_diameter_um` pushes the whole tail higher. The only lever that clears it
+is shrinking `bean_diameter_um` toward the schema's own 2000 µm floor, which
+trades a physically-accurate whole-bean size for schema compliance and is a
+workaround, not a fix. See `docs/current-state-and-gaps.md`.
+
 Compression and porosity respond to pressure through a bounded empirical curve:
 
 ```


### PR DESCRIPTION
- docs/model.md: explain that a wide burr gap can be grinder-valid but recipe-unusable because the output grid always tops out at bean_diameter_um, pushing tail bins past the recipe's 2000 um per-bin cap even when d32 is comfortably in-band -- distinct from the existing d32-out-of-range caveat.
- docs/current-state-and-gaps.md: add the same finding as an untriaged gap under "Model Limitations That Remain Gaps by Design," noting neither bins nor bean_diameter_um fixes it, and that a real fix (e.g. dropping negligible-mass tail bins before validation) hasn't been decided.


Claude-Session: https://claude.ai/code/session_01XBpBB9Kb3xE59ZfJe9Penz