### PR TITLE
deploy: host the dashboard live on Fly.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+build/
+build-debug/
+build-warnings/
+web/node_modules/
+web/dist/
+web/coverage/
+.git/
+results/
+profiling/
+CoffeeSim/
+.opencode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Multi-stage build for a single deployable EspressoLab instance:
+# the native REST tool_server plus the built React dashboard, served
+# together behind nginx. Matches scripts/dev.sh's shape (server on
+# 127.0.0.1:8734, web talking to it over /api) but as one container
+# with nginx as the public front door instead of the Vite dev server.
+
+# --- Stage 1: native C++ build (offline, vendored deps per CLAUDE.md) ---
+# Ubuntu 24.04 ships GCC 13 by default; GCC 12 (Debian bookworm's default)
+# doesn't fully implement <format>, which engine/artifact_io/hashing.cpp needs.
+FROM ubuntu:24.04 AS native-build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake g++ make ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DESPRESSOLAB_BUILD_TESTS=OFF \
+    && cmake --build build -j"$(nproc)" --target espressolab_server
+
+# --- Stage 2: web build ---
+FROM node:20-bookworm-slim AS web-build
+WORKDIR /src/web
+COPY web/package*.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+# --- Stage 3: runtime ---
+# Must match native-build's glibc/libstdc++ ABI, hence also Ubuntu 24.04.
+FROM ubuntu:24.04 AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nginx ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=native-build /src/build/apps/espressolab_server/espressolab_server /app/espressolab_server
+COPY assets /app/assets
+COPY espresso_real_world_refs /app/espresso_real_world_refs
+COPY --from=web-build /src/web/dist /app/web/dist
+COPY deploy/nginx.conf /etc/nginx/sites-enabled/default
+COPY deploy/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+EXPOSE 8080
+CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ stored measured-shot telemetry.
 Deterministic C++20 simulation core, React/TypeScript dashboard, interactive
 terminal UI, no AI, and separate experimental 2D and Cartesian 3D CFD solvers.
 
+**Live dashboard:** [espressolab-dashboard.fly.dev](https://espressolab-dashboard.fly.dev/)
+— the real native solver behind a hosted container (see `Dockerfile`), not a
+static demo; every control runs the same C++ core as the local build.
+
 ## Quick start
 
 ```bash

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+/app/espressolab_server --assets /app/assets --references /app/espresso_real_world_refs --port 8734 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+# Wait for the native server to bind before nginx starts proxying to it.
+for _ in $(seq 1 50); do
+    curl -sf http://127.0.0.1:8734/api/v1/health >/dev/null 2>&1 && break
+    sleep 0.2
+done
+
+nginx -g "daemon off;"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /app/web/dist;
+    index index.html;
+
+    # Static dashboard assets and client-side routing fallback.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Same-origin proxy to the native tool_server, which binds only to
+    # 127.0.0.1 and knows nothing of HTTP/CORS concerns itself (see
+    # CLAUDE.md: the server owns error translation and file boundaries,
+    # not transport). Mirrors web/vite.config.ts's dev proxy shape.
+    location /api/ {
+        proxy_pass http://127.0.0.1:8734/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 120s;
+    }
+}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,24 @@
+# fly.toml app configuration file generated for espressolab-dashboard on 2026-09-01T02:16:57-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'espressolab-dashboard'
+primary_region = 'iad'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024


### PR DESCRIPTION
Deploys EspressoLab's dashboard + native REST server as one container on Fly.io, so it's reachable from anywhere (phone, laptop) at:

**https://espressolab-dashboard.fly.dev/**

## What's added
- `Dockerfile` — multi-stage build: native C++ solver (`espressolab_server`), the built React app, and nginx serving both.
- `deploy/nginx.conf` — serves the static dashboard and proxies `/api/` to the native server on `127.0.0.1:8734` (same-origin, mirrors `web/vite.config.ts`'s dev proxy).
- `deploy/entrypoint.sh` — starts the native server, waits for `/api/v1/health`, then starts nginx.
- `fly.toml` — Fly.io app config (`espressolab-dashboard`, region `iad`, port 8080, scales to zero when idle).
- `.dockerignore` — keeps `build/`, `node_modules`, etc. out of the build context.
- README link to the live URL.

## Notes
- No architecture change: the dashboard still never computes a displayed quantity itself — it renders what the same native solver returns, per `CLAUDE.md`.
- GCC 12 (Debian bookworm's default) doesn't fully implement `<format>`, which `engine/artifact_io/hashing.cpp` uses, so both build and runtime stages use Ubuntu 24.04 (GCC 13) instead — kept the same base in both stages to avoid a glibc/libstdc++ ABI mismatch.
- The machine auto-stops when idle and cold-starts on the next request (Fly free tier), so the first hit after idle may take a few seconds.

## Verified
- Deployed build succeeded end-to-end.
- `GET /api/v1/health` returns solver/schema version info from the live URL.
- `GET /api/v1/recipes` then `POST /api/v1/shots` with a fetched recipe returned a real solved `ShotResult` (not a mock) — confirms the native solver runs correctly in the container, not just that nginx serves static files.
- Not run: the repo's automated test suites (`scripts/test.sh`, web Playwright) — this PR only adds deployment plumbing and a README link, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)