### PR TITLE
perf(web): defer chart bundles from initial dashboard load

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "espressolab-web",
       "version": "0.1.0",
       "dependencies": {
+        "lodash-es": "^4.18.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recharts": "^2.12.7"
@@ -17,6 +18,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.6",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.14.15",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -1448,6 +1450,23 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.43",
@@ -3247,7 +3266,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "test:e2e:all": "PLAYWRIGHT_FULL_MATRIX=1 playwright test"
   },
   "dependencies": {
+    "lodash-es": "^4.18.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^2.12.7"
@@ -24,6 +25,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.6",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.14.15",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -102,7 +102,7 @@ describe("App: workflow navigation", () => {
   it("preserves workflow-local state while switching tabs", async () => {
     const user = await renderApp();
     await user.click(screen.getByRole("tab", { name: "Sweeps" }));
-    const steps = screen.getByRole("spinbutton", { name: "steps" });
+    const steps = await screen.findByRole("spinbutton", { name: "steps" });
     await user.clear(steps);
     await user.type(steps, "7");
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,18 +1,33 @@
-import { useCallback, useRef, useState } from "react";
+import { Suspense, lazy, useCallback, useRef, useState } from "react";
 
 import { ApiFailure, api } from "./api/client";
 import type { Recipe, ShotResult } from "./api/types";
 import { type WorkflowId, WorkflowTabs } from "./app/WorkflowTabs";
 import { hasRecipe, useBootstrap } from "./app/useBootstrap";
-import { MeasuredShotComparison } from "./features/calibration/MeasuredShotComparison";
 import { ReferenceShotsPanel } from "./features/references/ReferenceShotsPanel";
 import { ShotWorkspace } from "./features/shot/ShotWorkspace";
-import { SweepPanel } from "./features/sweeps/SweepPanel";
 import {
   fallbackRecipe,
   localValidation,
   type ShotWorkspace as ShotWorkspaceState,
 } from "./state/workspace";
+
+// Both panels below are recharts consumers (see the note in ChartStack's
+// lazy import); they're the only two chart panels that render regardless of
+// which tab is active (hidden by CSS, not unmounted -- App: workflow
+// navigation's "preserves workflow-local state" contract needs them to stay
+// mounted once visited). Loading them eagerly would pull recharts back into
+// the initial bundle no matter how the Shot tab defers ChartStack, so each
+// is its own dynamic import and neither renders until its tab has been
+// opened at least once.
+const MeasuredShotComparison = lazy(() =>
+  import("./features/calibration/MeasuredShotComparison").then((mod) => ({
+    default: mod.MeasuredShotComparison,
+  })),
+);
+const SweepPanel = lazy(() =>
+  import("./features/sweeps/SweepPanel").then((mod) => ({ default: mod.SweepPanel })),
+);
 
 export function App() {
   const [selectedId, setSelectedId] = useState("baseline");
@@ -20,6 +35,19 @@ export function App() {
   const [sweepError, setSweepError] = useState<string>();
   const [pinned, setPinned] = useState<ShotResult[]>([]);
   const [activeWorkflow, setActiveWorkflow] = useState<WorkflowId>("shot");
+  // Tracks every tab that has ever been opened, so the Measured data and
+  // Sweeps panels (each `hidden`, not unmounted, once visited -- see the
+  // dynamic-import note above) mount their lazy chunk once and then stay
+  // mounted, instead of never rendering or re-fetching on every tab switch.
+  const [visitedWorkflows, setVisitedWorkflows] = useState<Set<WorkflowId>>(
+    () => new Set(["shot"]),
+  );
+  const changeWorkflow = useCallback((workflow: WorkflowId) => {
+    setActiveWorkflow(workflow);
+    setVisitedWorkflows((current) =>
+      current.has(workflow) ? current : new Set(current).add(workflow),
+    );
+  }, []);
   const draftTouched = useRef(false);
 
   const [workspace, setWorkspace] = useState<ShotWorkspaceState>({
@@ -132,7 +160,7 @@ export function App() {
           </>
         )}
       </header>
-      <WorkflowTabs active={activeWorkflow} onChange={setActiveWorkflow} />
+      <WorkflowTabs active={activeWorkflow} onChange={changeWorkflow} />
 
       <main className="main" id="main-content">
         {healthError && <div className="error" role="alert">{healthError}</div>}
@@ -185,7 +213,11 @@ export function App() {
             <h2>Measured data</h2>
             <p>Compare one stored shot with one native simulation. This workflow never fits coefficients.</p>
           </header>
-          <MeasuredShotComparison />
+          {visitedWorkflows.has("measured") && (
+            <Suspense fallback={<p className="note" aria-live="polite">Loading measured-data workflow...</p>}>
+              <MeasuredShotComparison />
+            </Suspense>
+          )}
         </section>
 
         <section
@@ -221,11 +253,15 @@ export function App() {
             <p>Run one- or two-axis experiments from the current draft recipe.</p>
           </header>
           {sweepError && <div className="error" role="alert">{sweepError}</div>}
-          <SweepPanel
-            baseline={workspace.draftRecipe}
-            parameters={health?.sweepable_parameters ?? ["puck.particle_diameter_um"]}
-            onError={setSweepError}
-          />
+          {visitedWorkflows.has("sweeps") && (
+            <Suspense fallback={<p className="note" aria-live="polite">Loading sweep workflow...</p>}>
+              <SweepPanel
+                baseline={workspace.draftRecipe}
+                parameters={health?.sweepable_parameters ?? ["puck.particle_diameter_um"]}
+                onError={setSweepError}
+              />
+            </Suspense>
+          )}
         </section>
       </main>
     </div>

--- a/web/src/a11y.test.tsx
+++ b/web/src/a11y.test.tsx
@@ -40,8 +40,9 @@ describe("Accessibility: stable application states", () => {
     );
     const user = userEvent.setup();
     const { container } = render(<App />);
-    await screen.findByLabelText(/measured shot/i);
+    await screen.findByRole("option", { name: /baseline/i });
     await user.click(screen.getByRole("tab", { name: /measured data/i }));
+    await screen.findByLabelText(/measured shot/i);
     await user.click(screen.getByRole("button", { name: /compare with default-v1/i }));
     await screen.findByText(/mass rmse/i);
     await expectNoSeriousViolations(container);
@@ -62,7 +63,7 @@ describe("Accessibility: stable application states", () => {
     const { container } = render(<App />);
     await screen.findByRole("option", { name: /baseline/i });
     await user.click(screen.getByRole("tab", { name: /sweeps/i }));
-    await user.click(screen.getByLabelText(/second axis \(heat map\)/i));
+    await user.click(await screen.findByLabelText(/second axis \(heat map\)/i));
     await user.click(screen.getByRole("button", { name: /run sweep/i }));
     await screen.findByRole("group", { name: /heat map of/i });
     await expectNoSeriousViolations(container);

--- a/web/src/features/shot/ShotWorkspace.tsx
+++ b/web/src/features/shot/ShotWorkspace.tsx
@@ -1,14 +1,20 @@
-import { useState } from "react";
+import { Suspense, lazy, useState } from "react";
 
 import type { Recipe, RecipeCatalogueEntry, ShotResult, ValidationIssue } from "../../api/types";
 import { preInfusionEnd } from "../../state/workspace";
 import { ComparisonTray } from "../comparison/ComparisonTray";
-import { ChartStack } from "./ChartStack";
 import { ControlRail } from "./ControlRail";
 import { DiagnosticsDrawer } from "./DiagnosticsDrawer";
 import { FlavorPanel } from "./FlavorPanel";
 import { MetricStrip } from "./MetricStrip";
 import { PuckView } from "./PuckView";
+
+// recharts (and the d3/decimal.js chain it pulls in) is the single largest
+// contributor to the production bundle -- see the bundle-visualizer note in
+// vite.config.ts. ChartStack only ever renders once a shot has run, so a
+// dynamic import keeps that weight out of the chunk needed just to open the
+// workbench and edit a recipe.
+const ChartStack = lazy(() => import("./ChartStack").then((mod) => ({ default: mod.ChartStack })));
 
 interface Props {
   recipes: RecipeCatalogueEntry[];
@@ -79,12 +85,14 @@ export function ShotWorkspace({
               targetBeverageG={activeRecipe?.stop.target_beverage_g ?? null}
               cursorTimeSeconds={cursorTimeSeconds}
             />
-            <ChartStack
-              result={active}
-              comparisons={comparisons}
-              preInfusionEnd={activeRecipe ? preInfusionEnd(activeRecipe) : undefined}
-              onCursorChange={setCursorTimeSeconds}
-            />
+            <Suspense fallback={<p className="note" aria-live="polite">Loading charts...</p>}>
+              <ChartStack
+                result={active}
+                comparisons={comparisons}
+                preInfusionEnd={activeRecipe ? preInfusionEnd(activeRecipe) : undefined}
+                onCursorChange={setCursorTimeSeconds}
+              />
+            </Suspense>
             <ComparisonTray
               runs={pinned}
               activeId={active.manifest.run_id}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,18 @@ const proxyTarget = process.env.ESPRESSOLAB_SERVER_URL ?? "http://127.0.0.1:8734
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      // recharts imports individual lodash submodules (lodash/get, lodash/isNumber,
+      // ...); lodash's CJS internals require() shared helpers that Rollup's CJS
+      // interop can't tree-shake, so the whole library rides along for ~28 used
+      // functions. lodash-es ships the same functions as real ESM, so only what's
+      // actually imported ends up in the bundle. This doesn't touch our own code --
+      // we have no direct lodash usage.
+      { find: /^lodash\/(.*)$/, replacement: "lodash-es/$1" },
+      { find: "lodash", replacement: "lodash-es" },
+    ],
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Problem
The dashboard production build on `origin/main` shipped a `597,368` byte (`597.30 kB`) initial JavaScript chunk and emitted Vite's >500 kB warning. Recharts and its lodash dependency chain were needed before a user opened a chart-bearing workflow.

## Implementation
- Alias Recharts' lodash submodule imports to the ESM `lodash-es` package for tree-shaking.
- Lazy-load `ChartStack`, measured-shot comparison, and sweep panels with accessible `Suspense` fallbacks.
- Track visited workflows so lazy panels remain mounted after first visit, preserving local state while tabs are switched.
- Update asynchronous UI and accessibility tests to wait for deferred workflow content.
- Merged `origin/main` into the branch without rebasing; current deployment and documentation changes are preserved.

## Why this approach
Dynamic imports defer code that is not needed to open and edit the Shot workspace, while keeping existing component boundaries and tab-state behavior. The visited-workflow set avoids re-fetching or remounting panels on navigation. The ESM lodash alias reduces the deferred chart dependency payload without adding manual, brittle vendor chunks.

## Before and after
Measured with the same Vite production build and `stat`/`gzip` output:

| Metric | `origin/main` | This branch |
| --- | ---: | ---: |
| Initial JS | 597,368 B / 172,158 B gzip | 190,915 B / 61,255 B gzip |
| Initial JS reduction | - | 68.0% raw / 64.4% gzip |
| Total emitted JS | 597,368 B / 172,158 B gzip | 595,450 B / 172,493 B gzip |

Deferred chunks on this branch:
- `LineChart`: 379,134 B / 101,959 B gzip
- `SweepPanel`: 11,776 B / 4,299 B gzip
- `MeasuredShotComparison`: 7,840 B / 2,696 B gzip
- `ChartStack`: 5,785 B / 2,284 B gzip

The >500 kB warning is gone because no individual emitted chunk exceeds the threshold. Total JavaScript transfer is essentially unchanged; this improves initial load, not total download volume.

## Verification
- `npm run typecheck`
- `npm run test:coverage` (`18` files, `222` tests passed; `96.52%` statements, `87.96%` branches)
- `npm run build`
- `./scripts/build.sh`
- `./scripts/test.sh` (`226` cases, `86,773` assertions)
- `./scripts/demo.sh` (determinism check passed; baseline hash `80156b2e...` repeated)
- `npm run test:e2e` (`26` Chromium desktop/mobile tests passed, including simulation, pinned comparison, measured data, sweeps, and keyboard workflows)

## Risks and limitations
- The first visit to a chart-bearing workflow waits for its deferred chunk; the UI renders an `aria-live` loading message rather than a blank panel.
- The total bundle is not materially smaller; only the initial application load is reduced.
- Recharts remains on the current v2 dependency line; the lodash alias should be rechecked during a future Recharts major upgrade.

## Solver outputs
No native solver or artifact code changed. Simulation outputs and result hashes are unchanged by this branch.

## Related issue
No dedicated chart-bundle issue was open; this completes the repository's stated initial performance-branch priority.