### PR TITLE
docs: refresh deployment and verification status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@ The PTY script's 15 checks pass. Locally verified for the overlay: full suite,
 warnings-as-errors build, `scripts/demo.sh`, `scripts/calibration_demo.sh`, the
 18-case schema contract check, the PTY matrix, web typecheck/coverage/build, and
 Chromium desktop/mobile Playwright tests.
-Hosted macOS, Linux, and dashboard jobs passed at `736cef3`; later hardening
-through `94fbe7a` does not yet have equivalent hosted evidence.
+Hosted macOS, Linux, dashboard, and the full nightly browser matrix passed for
+current `origin/main` at `347177c` in run `33508004359`.
 
 Debug build, isolated from `build/`:
 

--- a/README.md
+++ b/README.md
@@ -296,10 +296,11 @@ smoke script (`python3 tests/pty/tui_smoke.py`) defines 15 checks for the TUI's
 actual terminal rendering, form execution/scrolling, resize, Ctrl-C, restoration,
 and non-TTY rejection; it is not part of `./scripts/test.sh` and passes locally.
 The web suite passes 222 Vitest tests with coverage thresholds and 26 Chromium
-desktop/mobile Playwright tests against the native server. Hosted GitHub Actions passed the macOS, Linux,
-and dashboard jobs at commit `736cef3`; current branch hardening through
-`94fbe7a` has local evidence but no equivalent hosted run recorded here. See
-[docs/testing.md](docs/testing.md).
+desktop/mobile Playwright tests against the native server. Hosted GitHub Actions
+passed the macOS, Linux, dashboard, and full nightly browser matrix for current
+`origin/main` at [`347177c`](https://github.com/Supersmasher149/CoffeeSim/commit/347177c)
+in [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359).
+See [docs/testing.md](docs/testing.md).
 
 ## Documentation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,12 @@
-# Local API
+# API
 
 `espressolab_server` binds `127.0.0.1` (default port 8734) and serves the
-endpoints below. It is a local tool server: no accounts, no auth, no cloud
-deployment, and no persistence across a server restart. For ownership and
-versioning of every request and response document, see
+endpoints below when run locally. The repository also packages the same server
+with the dashboard for the [live Fly.io deployment](https://espressolab-dashboard.fly.dev/).
+The examples below use the local port. Neither mode provides accounts,
+authentication, or persistence across a server restart; the hosted instance is
+a single shared session-bound service. For ownership and versioning of every
+request and response document, see
 [data-contracts.md](data-contracts.md).
 
 ```bash

--- a/docs/current-state-and-gaps.md
+++ b/docs/current-state-and-gaps.md
@@ -1,16 +1,17 @@
 # EspressoLab: Current State and Gaps
 
-**Assessment date:** 2026-08-27
+**Assessment date:** 2026-09-01
 **Scope:** Repository state under `espressolab/`
 **Audience:** Project stakeholders, technical contributors, and portfolio reviewers
 
 ## Executive Summary
 
-EspressoLab has reached a substantially complete engineering MVP. It is a local
-espresso-simulation workbench with a deterministic C++20 simulation core, CLI,
-local REST server, React/TypeScript dashboard, reproducible JSON and CSV
+EspressoLab has reached a substantially complete engineering MVP. It is a
+local-first espresso-simulation workbench with a deterministic C++20 simulation
+core, CLI, REST server, React/TypeScript dashboard, reproducible JSON and CSV
 artifacts, parameter sweeps, measured-shot comparison, calibration tooling, and
-separate 2D axisymmetric and Cartesian 3D CFD solvers.
+separate 2D axisymmetric and Cartesian 3D CFD solvers. The repository also has
+an optional single-container Fly.io deployment for the dashboard and REST server.
 
 The project is strong on software structure, reproducible experiments, and
 automated verification of its standard configurations. It is not yet a
@@ -30,9 +31,11 @@ EspressoLab simulates a shot from controllable brew inputs and exposes pressure,
 temperature, flow, beverage mass, TDS, and extraction over time. It supports
 reproducible recipe comparison through parameter sweeps.
 
-The project is intentionally a local engineering workbench. It has no accounts,
-authentication, cloud deployment, database, or remote backend service; its REST
-server is local and session-bound.
+The project remains local-first: the default development workflow runs the REST
+server and dashboard on the user's machine. The repository also includes a
+single-container Fly.io deployment at
+https://espressolab-dashboard.fly.dev/. The hosted instance has no accounts,
+authentication, database, or durable storage; its server state is session-bound.
 
 ---
 
@@ -47,7 +50,7 @@ server is local and session-bound.
 | CFD | Separate 2D axisymmetric and Cartesian 3D finite-volume solvers with pressure, saturation, enthalpy, and solute transport | Implemented as explicit CLI paths; 3D also has asynchronous REST status/snapshot routes; verified, not validated |
 | CLI | `simulate`, `sweep`, `calibrate`, `synthesize`, `cfd`, `cfd3d`, `grind`, `bench`, `params`, `fit-params`, and `version` commands | Implemented |
 | Terminal UI | `espressolab_cli tui`: guided forms over every CLI command, calling the same shared workflow services as the file-oriented commands; cooperative cancellation; POSIX-only | Implemented; native logic and the 15-check PTY matrix pass locally |
-| REST server | Local API for health, recipes, references, measured-shot catalogue/comparison, shots, asynchronous sweeps and CFD3D jobs, cancellation, status, snapshots, and CSV artifacts | Implemented |
+| REST server | API for health, recipes, references, measured-shot catalogue/comparison, shots, asynchronous sweeps and CFD3D jobs, cancellation, status, snapshots, and CSV artifacts | Implemented locally and packaged with the dashboard for Fly.io; session-bound and unauthenticated |
 | Dashboard | Recipe controls, measured-shot comparison, draggable pressure and temperature profiles, synchronized charts, pinned runs, sweep heat maps, progress/cancellation, exports, diagnostics, and puck cross-section replay | Implemented; 222 Vitest tests and 26 Chromium desktop/mobile Playwright tests pass locally |
 | Artifacts | Versioned standard-shot and CFD3D inputs/results, JSON/CSV output, `ELF3D-1` snapshot fields, manifests, and SHA-256 hashes | Implemented |
 | Calibration | Bounded deterministic fitting, held-out validation, leave-one-shot-out workflow, provenance, and synthetic-data workflow | Tooling implemented; real-data evidence absent |
@@ -97,9 +100,9 @@ The repository documents the following local checks:
   not run PTY, dashboard, demo, or warnings-as-errors checks.
 - The dashboard typecheck, coverage suite, and production build succeed; Vite
   reports a non-blocking 597.30 kB minified JavaScript chunk warning.
-- GitHub Actions macOS, Linux, and dashboard jobs passed at commit `736cef3`.
-  Later hardening through current branch commit `94fbe7a` has no equivalent
-  hosted run recorded here.
+- GitHub Actions macOS, Linux, dashboard, and full nightly browser-matrix jobs
+  passed for current `origin/main` commit `347177c` in
+  [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359).
 - The demo covers a baseline shot, a nine-run grind sweep, JSON/CSV artifacts,
   and repeated-run hash equality.
 - The baseline reaches 36 g in approximately 29.03 seconds with no clamps and
@@ -148,7 +151,6 @@ and output should be presented as a model result rather than a prediction.
 
 | Gap | Impact | Completion signal |
 | --- | --- | --- |
-| Current-branch hosted CI evidence is absent | Commit `736cef3` passed macOS/Linux/dashboard jobs, but later hardening through `94fbe7a` has only local evidence recorded here | Hosted workflow passes at the current branch head |
 | Dashboard has a non-blocking 597.30 kB minified JavaScript chunk warning | Does not block the MVP, but indicates a performance/packaging follow-up for a polished release | Chunk is reduced or the warning is explicitly accepted with measured load impact |
 | Portfolio packaging is unfinished | The project is not yet represented by a final demo video and evidence-based resume/project claims | Demo recording and portfolio copy use only verified benchmark and validation results |
 
@@ -160,15 +162,17 @@ and output should be presented as a model result rather than a prediction.
 - Shots, sweeps, and CFD3D jobs are retained only in process memory. Restarting
   the server loses them, and older entries are evicted from bounded
   session-local caches.
-- The API is local-only and has no authentication, authorization, CORS support,
-  cloud deployment, persistence, or multi-user operation. These are out of MVP
-  scope, but they are gaps for any hosted or collaborative product.
-- There is no documented installer or single packaged distribution for the
-  native server, CLI, and dashboard. Users currently build from the repository
-  and run the supplied scripts.
+- The API has no authentication, authorization, CORS support, persistence, or
+  multi-user operation. The Fly.io deployment is a single shared instance, not
+  a hosted collaborative product, and these remain gaps for that use case.
+- There is no documented installer or standalone distribution for the native
+  server, CLI, and dashboard. The Dockerfile provides a deployable
+  dashboard/server image and `fly.toml` provides the Fly.io configuration, but
+  the CLI/TUI still require a source build.
 - The frontend browser suite currently covers Chromium desktop and mobile on
-  every pull request; Firefox/WebKit remain a nightly matrix, and hosted
-  current-head evidence is still pending.
+  every pull request; Firefox/WebKit remain a nightly matrix. The current
+  `origin/main` has hosted evidence for both native platforms and the full
+  browser matrix in [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359).
 
 ### Model Limitations That Remain Gaps by Design
 
@@ -224,12 +228,13 @@ project can support:
 2. Run leave-one-out calibration, inspect held-out mass/time/TDS errors, and
    publish a new provenance-bearing coefficient file only if the acceptance gate
    passes.
-3. Run hosted CI at the current branch head.
+3. Keep hosted CI green for future branch heads.
 4. Update the README and portfolio materials with measured claims only; record
    the demo video.
-5. Decide whether the project remains a local engineering workbench or needs
-   persistence, packaging, and deployment work. Do not add those capabilities
-   before the validation decision unless the product goal changes.
+5. Decide whether the project needs persistence, multi-user operation, and
+   broader packaging beyond the existing single-container Fly.io deployment.
+   Do not add those capabilities before the validation decision unless the
+   product goal changes.
 6. Treat a calibration dashboard and further model fidelity as follow-up work
    after real-shot evidence exists.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,11 @@
 # Getting Started
 
 EspressoLab is a local engineering workbench. The native solver, REST server,
-and browser dashboard run on your machine; there is no hosted service, account,
-or database to configure.
+and browser dashboard can run on your machine, and the repository also includes
+an optional [Fly.io deployment](https://espressolab-dashboard.fly.dev/). The
+hosted instance runs the same native solver in a single container. Neither local
+nor hosted mode has accounts, authentication, or a database; server-held runs
+remain session-bound.
 
 ## Requirements
 
@@ -80,6 +83,14 @@ use another `--out` directory when you need to preserve an earlier run.
 The script starts the local REST server on `127.0.0.1:8734` and the Vite
 development server on `http://localhost:5173`. Open the Vite URL in a browser.
 Stopping the script with `Ctrl-C` also stops the server process it launched.
+
+### Hosted dashboard
+
+The optional [live dashboard](https://espressolab-dashboard.fly.dev/) packages
+the built React application and native REST server behind one same-origin
+endpoint. It is a single shared demonstration instance, not a persistent or
+multi-user service; use the local workflow above when developing or preserving
+session data.
 
 The dashboard posts recipes to the native solver and renders its response. It
 does not reimplement the espresso model in TypeScript. Use the Shot, Measured

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,16 +9,17 @@ validated against real espresso shots.
 
 The engineering MVP is substantially complete. The deterministic C++20 core,
 CLI, REST server, React/TypeScript dashboard, artifacts, sweeps, calibration
-machinery, and documentation are implemented. The remaining release work is
-real-world validation and portfolio packaging, plus hosted CI evidence for the
-latest hardening commits.
+machinery, and documentation are implemented. A single-container Fly.io
+deployment and current-head hosted CI evidence are also in place. The remaining
+release work is real-world validation and portfolio packaging, plus any future
+operational work beyond that single shared instance.
 
 | Week | Focus from the guide | Status | Evidence |
 | --- | --- | --- | --- |
 | 1 | Skeleton, domain types, profiles, units, water properties, flow-only CLI | Complete | Core/model targets, unit tests, and CLI are present. |
 | 2 | Thermal state, wetting, extraction, mass balances, artifacts, determinism | Complete | Integration, invariant, convergence, and artifact tests pass. |
 | 3 | Sweep runner, REST server, React controls, synchronized charts, exports | Complete | Server routes, dashboard source, background sweeps, and production web build are present. |
-| 4 | Calibration, edge cases, CI, README, profiling, demo, portfolio packaging | Partial | Calibration and measured-shot comparison tooling, edge-case tests, documentation, benchmark, CLI demo, and hosted macOS/Linux/dashboard evidence at `736cef3` are complete; real calibration, current-head hosted evidence, demo video, and measured portfolio claims remain. |
+| 4 | Calibration, edge cases, CI, README, profiling, demo, portfolio packaging | Partial | Calibration and measured-shot comparison tooling, edge-case tests, documentation, benchmark, CLI demo, and hosted macOS/Linux/dashboard plus full browser-matrix evidence at current `origin/main` commit `347177c` are complete; real calibration, demo video, and measured portfolio claims remain. |
 
 ## Verified Locally
 
@@ -30,15 +31,17 @@ latest hardening commits.
   the built native server.
 - The Vitest suite passes 222 tests with its configured coverage thresholds.
 - The PTY matrix passes all 15 checks.
-- Hosted GitHub Actions macOS, Linux, and dashboard jobs passed at commit
-  `736cef3`. Current branch hardening through `94fbe7a` has no equivalent hosted
-  run recorded here.
+- Hosted GitHub Actions macOS, Linux, dashboard, and full nightly browser-matrix
+  jobs passed for current `origin/main` commit `347177c` in
+  [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359).
 - `./scripts/demo.sh` completes the documented CLI acceptance path:
   baseline simulation, nine-run grind-size sweep, JSON/CSV artifacts, and an
   identical SHA-256 result hash on rerun.
 - The Vite-served dashboard loads and proxies `/api/v1` to the local server.
   Through that path, shot execution, shot CSV export, completed sweep CSV export,
   and cancelled-sweep partial CSV export all succeed.
+- The [Fly.io deployment](https://espressolab-dashboard.fly.dev/) serves the
+  built dashboard and responds to `/api/v1/health` from the native server.
 - `espressolab_cli bench` records a 60-second, 100 Hz shot in 0.468 ms median,
   42.7x inside the guide's 20 ms performance budget.
 - The baseline run reaches the 36 g target in 29.03 s with no clamps and closes
@@ -55,7 +58,7 @@ latest hardening commits.
 | Reproduce the same result hash | Verified locally | The demo reports matching SHA-256 hashes. |
 | Pass conservation and convergence tests | Verified locally | Covered by the passing test suite. |
 | Run and compare shots in the browser | Verified locally | Chromium desktop/mobile Playwright coverage passes for profile editing, keyboard navigation, downloads, determinism, measured-shot comparison, sweeps, and issue #22 recipe binding. |
-| Clean-clone macOS and Linux verification | Verified at `736cef3`; current head pending | Hosted macOS, Linux, and dashboard jobs passed at `736cef3`; do not extend that evidence to hardening through `94fbe7a` until another run passes. |
+| Clean-clone macOS, Linux, and dashboard verification | Verified at current `origin/main` | Hosted macOS, Linux, dashboard, and full browser-matrix jobs passed for `347177c` in run 33508004359. |
 
 ## Completed Week 4 Tooling
 
@@ -91,9 +94,9 @@ latest hardening commits.
   recovery tests validate the fitter, not the espresso model. The CLI now
   supports leave-one-shot-out validation for three or more fixed-setup shots;
   supplying and running those real measurements is the highest-value next step.
-- **Confirm current-head hosted CI.** The committed workflow passed on macOS,
-  Linux, and the dashboard at `736cef3`. Run it again for hardening through
-  `94fbe7a`; the older result is not evidence for those later commits.
+- **Maintain current-head hosted CI evidence.** The committed workflow passes on
+  macOS, Linux, the dashboard, and the browser matrix at `347177c`; future
+  changes require a new hosted run.
 - **Finish portfolio packaging.** Record the demo video and write resume bullets
   from the verified benchmark and, after calibration, measured validation data.
 - **Calibration dashboard view.** The dashboard now compares measured telemetry

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -296,7 +296,8 @@ for reproducibility, not for correctness.
 `./scripts/demo.sh` is the local acceptance workflow: from a clean clone, run
 the baseline recipe, complete a grind-size sweep, export JSON and CSV, and rerun
 the same inputs to the same result hash. GitHub Actions macOS, Linux, and
-dashboard jobs passed at commit `736cef3`. Later hardening on the current branch
-through `94fbe7a` has no equivalent hosted run recorded here, so do not extend
-that hosted evidence to the current branch. See
+dashboard, and full nightly browser-matrix jobs passed for current `origin/main`
+at commit `347177c` in [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359).
+Future changes need their own hosted run; do not extend this evidence to an
+unrelated branch. See
 [current-state-and-gaps.md](current-state-and-gaps.md) for the evidence status.


### PR DESCRIPTION
## Problem
Several release-readiness documents still described EspressoLab as having no cloud deployment and cited hosted evidence only through `736cef3`, even though PR #51 added the live Fly.io deployment and current `origin/main` has a successful hosted workflow.

## Implementation
- Document the optional Fly.io dashboard/native-server deployment in the getting-started and API guides.
- Correct the README, contributor instructions, testing guide, roadmap, and current-state report to cite current commit `347177c` and hosted workflow run `33508004359`.
- Keep local-first behavior, session-bound state, missing authentication/persistence, and the current main-branch bundle warning explicit.
- Reframe the remaining packaging gap around a native CLI/TUI installer rather than claiming no deployment exists.

## Evidence
- Live dashboard: https://espressolab-dashboard.fly.dev/
- Live `/api/v1/health`: responds with `status: ok` and `solver_version: solver-0.4.0`.
- Hosted workflow for `origin/main` `347177c`: [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359), with macOS native, Ubuntu native, dashboard, and full nightly browser-matrix jobs passing.

## Verification
- `git diff --check`
- Active-document stale-claim search: no obsolete `736cef3`, `94fbe7a`, or no-hosted-deployment statements remain.
- `./scripts/test.sh` (`226` cases, `86,773` assertions)
- `npm run typecheck`
- `npm run test:coverage` (`222` tests passed)
- `npm run build` (passes; the documented `597.30 kB` main-branch warning remains expected until PR #52 merges)

## Scope and risk
Documentation only. No solver, artifact, schema, or result-hash behavior changes. Historical design specs retain their original context.

## Related work
Complements PR #51 (Fly.io deployment) and PR #52 (chart bundle deferral). No numbered issue is being closed by this documentation refresh.