### PR TITLE
docs: refresh dashboard bundle status

### DIFF
--- a/docs/current-state-and-gaps.md
+++ b/docs/current-state-and-gaps.md
@@ -98,8 +98,13 @@ The repository documents the following local checks:
 
 - `./scripts/test.sh` passes 226 Catch2 test cases and 86,773 assertions. It does
   not run PTY, dashboard, demo, or warnings-as-errors checks.
-- The dashboard typecheck, coverage suite, and production build succeed; Vite
-  reports a non-blocking 597.30 kB minified JavaScript chunk warning.
+- The dashboard typecheck, coverage suite, and production build succeed. PR #52
+  reduced the initial JavaScript payload from 597,368 B / 172,158 B gzip to
+  190,915 B / 61,255 B gzip (68.0% raw / 64.4% gzip). PR #52 brought every
+  emitted JavaScript chunk below Vite's 500 kB threshold. Total emitted
+  JavaScript is essentially unchanged, changing from 597,368 B / 172,158 B
+  gzip to 595,450 B / 172,493 B gzip. This is an initial-load improvement, not
+  a reduction in total transfer.
 - GitHub Actions macOS, Linux, dashboard, and full nightly browser-matrix jobs
   passed for current `origin/main` commit `347177c` in
   [run 33508004359](https://github.com/Supersmasher149/CoffeeSim/actions/runs/33508004359).
@@ -151,7 +156,7 @@ and output should be presented as a model result rather than a prediction.
 
 | Gap | Impact | Completion signal |
 | --- | --- | --- |
-| Dashboard has a non-blocking 597.30 kB minified JavaScript chunk warning | Does not block the MVP, but indicates a performance/packaging follow-up for a polished release | Chunk is reduced or the warning is explicitly accepted with measured load impact |
+| Dashboard initial-load packaging | Resolved by PR #52: initial JavaScript fell from 597,368 B / 172,158 B gzip to 190,915 B / 61,255 B gzip, and every emitted JavaScript chunk is below 500 kB. Total emitted JavaScript remains essentially unchanged at 595,450 B / 172,493 B gzip. | Future performance reporting distinguishes initial payload from total transfer |
 | Portfolio packaging is unfinished | The project is not yet represented by a final demo video and evidence-based resume/project claims | Demo recording and portfolio copy use only verified benchmark and validation results |
 
 ### Product and Operational Gaps

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,8 +25,12 @@ operational work beyond that single shared instance.
 
 - `./scripts/test.sh` passes: 226 Catch2 test cases and 86,773 assertions.
 - `npm --prefix web run typecheck`, `npm --prefix web run test:coverage`, and
-  `npm --prefix web run build` succeed. Vite reports a non-blocking 597.30 kB
-  minified JavaScript chunk-size warning.
+  `npm --prefix web run build` succeed. PR #52 brought every emitted JavaScript
+  chunk below Vite's 500 kB threshold and reduced initial JavaScript from
+  597,368 B / 172,158 B gzip to 190,915 B / 61,255 B gzip (68.0% raw / 64.4%
+  gzip). Total emitted JavaScript is essentially unchanged, changing from
+  597,368 B / 172,158 B gzip to 595,450 B / 172,493 B gzip, so this is an
+  initial-load improvement rather than a total-transfer reduction.
 - `npm --prefix web run test:e2e` passes 26 Chromium desktop/mobile tests against
   the built native server.
 - The Vitest suite passes 222 tests with its configured coverage thresholds.


### PR DESCRIPTION
## Summary

- Replace stale documentation claiming the dashboard still emits Vite's 597.30 kB chunk warning.
- Record PR #52's measured initial JavaScript reduction and unchanged total emitted JavaScript.
- Mark the initial-load packaging gap resolved without changing the remaining hosted-CI or real-shot validation gaps.

## Verification

- `git diff --check`
- Stale active-warning search across both updated documents
- Independent verification in a separate worktree at `a5a2b82`

No full build was run because this is documentation-only.
