### PR TITLE
feat(validation): real-shot capture template and first fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: python3 tests/server/measured_shots_smoke.py
 
+      # Real-shot capture records must keep unmeasured values null and stay out
+      # of the calibrate directory (docs/real-shot-validation.md). Stdlib only.
+      - name: Real-shot capture contract check
+        if: matrix.os == 'ubuntu-latest'
+        run: python3 tests/schemas/real_shot_capture_check.py
+
       # Definition of done (section 2.2): baseline recipe, grind sweep, both
       # artifacts exported, identical result hash on rerun.
       - name: Acceptance demo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,10 +179,12 @@ recipe, coefficient, configuration, and result hashes.
 | `apps/espressolab_server/` | Local REST translation, measured-shot comparison, in-memory runs, background sweep/CFD3D jobs (cpp-httplib) |
 | `web/src/features/` | shot, sweeps, run comparison, measured-shot comparison, calibration notice |
 | `assets/beans/` | Bean profiles for the sensory overlay. Authored priors, never measured |
+| `assets/real_shots/` | Real-shot capture records and templates. Inert: no build, solver, server or calibration path reads them |
 | `assets/` | Versioned example inputs and synthetic measurement fixtures |
 | `schemas/` | Intended JSON exchange formats |
 | `tests/` | Unit, integration, property, convergence, verification tests |
 | `tests/pty/` | POSIX PTY smoke matrix for the TUI (outside `ctest`; needs a real pseudo-terminal) |
+| `tests/schemas/` | Document-contract checks run outside `ctest`: `real_shot_capture_check.py` (stdlib, in CI) and `schema_contract_check.py` (needs unvendored `jsonschema`, run by hand) |
 
 ### Runtime data flow
 
@@ -314,10 +316,11 @@ reproducibility, not correctness.
 | `docs/architecture.md` | Component boundaries and the dependency rule |
 | `docs/api.md` | REST endpoints and the error contract |
 | `docs/calibration.md` | Fitting coefficients to measured shots |
+| `docs/real-shot-validation.md` | Where real measured-shot data can come from, the capture protocol, and how a capture is compared against a simulation |
 | `docs/testing.md` | What each test layer is for |
 | `docs/roadmap.md` | Status against the four-week plan, and what's not done |
 | `docs/current-state-and-gaps.md` | Evidence-based implementation status and open gaps |
-| `schemas/` | JSON Schema for recipes, coefficients, shot results, CFD3D cases/results, grinder specs/results |
+| `schemas/` | JSON Schema for recipes, coefficients, shot results, CFD3D cases/results, grinder specs/results, real-shot captures |
 
 ## Requirements
 

--- a/assets/measured_shots/README.md
+++ b/assets/measured_shots/README.md
@@ -30,6 +30,11 @@ espressolab_cli calibrate --shots assets/measured_shots \
 Write fitted coefficients and reports somewhere else: every `.json` in this
 directory is read as a measured shot.
 
+Records of *physically brewed* shots live in `assets/real_shots/` instead, in a
+richer format that also states what was not measured. They are deliberately not
+readable here; see `docs/real-shot-validation.md` for the capture protocol and
+for when a capture may be promoted into this directory.
+
 Rules from 11.3, worth repeating because they are what make the numbers usable:
 
 - Record time and beverage mass first; add pressure and TDS only if the

--- a/assets/real_shots/2026-09-01-pending-capture-01.capture.json
+++ b/assets/real_shots/2026-09-01-pending-capture-01.capture.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "1.0",
+  "kind": "real_shot_capture",
+  "id": "2026-09-01-pending-capture-01",
+  "status": "pending_capture",
+  "capture": {
+    "utc_timestamp": null,
+    "operator": null,
+    "protocol_version": "1.0"
+  },
+  "provenance": {
+    "source": "first-party capture (not yet performed)",
+    "source_url": null,
+    "license": null,
+    "retrieved_at": null,
+    "data_quality_flags": [
+      "pending_capture: no shot has been brewed against this record. Every observable is null by design and must stay null until a real shot is recorded.",
+      "No particle size distribution is planned for the first capture; grind.measured stays false and grinder.dial_setting is recorded verbatim as text. A dial number must never be converted to microns.",
+      "preparation.puck_depth_mm and grind PSD are solver inputs no consumer machine reports; until both are measured this record cannot be promoted to assets/measured_shots/ and simulation_link.recipe stays null."
+    ],
+    "calibration_eligible": false,
+    "validation_eligible": false
+  },
+  "machine": {
+    "model": null,
+    "firmware": null,
+    "basket": null,
+    "portafilter_diameter_mm": null,
+    "pressure_sensor_measures": null,
+    "pressure_sensor_location": null,
+    "temperature_sensor_location": null
+  },
+  "grinder": {
+    "model": null,
+    "burrs": null,
+    "dial_setting": null,
+    "rpm": null
+  },
+  "grind": {
+    "measured": false,
+    "method": null,
+    "d10_um": null,
+    "d50_um": null,
+    "d90_um": null,
+    "sauter_mean_d32_um": null,
+    "distribution": []
+  },
+  "coffee": {
+    "roaster": null,
+    "name": null,
+    "origin": null,
+    "process": null,
+    "roast_level": null,
+    "roast_date": null,
+    "days_off_roast": null,
+    "storage": null
+  },
+  "preparation": {
+    "dose_g": null,
+    "dose_scale_resolution_g": null,
+    "basket": null,
+    "distribution_technique": null,
+    "tamp": null,
+    "filter_paper": null,
+    "puck_screen": null,
+    "puck_depth_mm": null
+  },
+  "water": {
+    "recipe_name": null,
+    "source": null,
+    "tds_ppm": null,
+    "general_hardness_ppm_caco3": null,
+    "alkalinity_ppm_caco3": null
+  },
+  "temperature": {
+    "setpoint_c": null,
+    "measured_c": null,
+    "measurement_point": null,
+    "measurement_method": null,
+    "note": null
+  },
+  "pressure": {
+    "profile_name": null,
+    "profile_description": null,
+    "nominal_peak_bar": null,
+    "preinfusion": null
+  },
+  "timing": {
+    "convention": null,
+    "first_drip_s": null,
+    "end_condition": null,
+    "total_shot_time_s": null
+  },
+  "result": {
+    "beverage_yield_g": null,
+    "yield_scale_resolution_g": null,
+    "tds_percent": null,
+    "tds_method": {
+      "instrument": null,
+      "filtered": null,
+      "sample_temperature_c": null,
+      "repeats": null,
+      "readings_percent": []
+    },
+    "extraction_yield_percent": null,
+    "extraction_yield_source": null
+  },
+  "telemetry": {
+    "csv": null,
+    "columns": [],
+    "sample_rate_hz": null,
+    "row_count": null,
+    "time_origin": null
+  },
+  "observations": {
+    "taste": null,
+    "channeling": null,
+    "puck_condition": null,
+    "anomalies": [],
+    "notes": "ACQUISITION INSTRUCTIONS -- follow docs/real-shot-validation.md section \"Capture protocol 1.0\". Copy assets/real_shots/TEMPLATE.capture.json to a new file named <id>.capture.json, copy TEMPLATE.telemetry.csv beside it as <id>.telemetry.csv, and fill fields ONLY from things you measured. Leave anything you did not measure as null; do not carry a setpoint into temperature.measured_c, do not derive a PSD from a grinder dial, and record whether the logged pressure is pump or puck pressure. Brew at least five shots on one machine with one coffee, one water recipe, one basket and one preparation, varying only grind; reserve at least one for held-out validation and never fit on it. This record is the reserved slot for shot 01."
+  },
+  "attachments": {
+    "raw_shot_file": null,
+    "telemetry_csv": null,
+    "photos": [],
+    "video": null
+  },
+  "simulation_link": {
+    "recipe": null,
+    "unavailable_model_inputs": [
+      "puck.particle_diameter_um / puck.grind (no PSD measurement planned)",
+      "puck.depth_mm (must be measured on the tamped bed)",
+      "measured inlet water temperature (machine setpoint is not an observation)"
+    ],
+    "comparable_observables": []
+  }
+}

--- a/assets/real_shots/README.md
+++ b/assets/real_shots/README.md
@@ -1,0 +1,52 @@
+# Real-shot captures
+
+Records of physically brewed espresso shots, kept for validating the simulator
+against reality. **Nothing here is read by the build, the solver, the server or
+`espressolab_cli calibrate`.**
+
+The protocol, the researched data sources, and the comparison rules are in
+[`docs/real-shot-validation.md`](../../docs/real-shot-validation.md). The
+document format is [`schemas/real-shot-capture.schema.json`](../../schemas/real-shot-capture.schema.json),
+enforced by `tests/schemas/real_shot_capture_check.py`.
+
+## Contents
+
+| File | What it is |
+| --- | --- |
+| `TEMPLATE.capture.json` | Copy this per shot. Every field present, every value null |
+| `TEMPLATE.telemetry.csv` | Copy this per shot. Header only: `time_s,pressure_bar,flow_ml_s,cumulative_beverage_mass_g,temperature_c` |
+| `2026-09-01-pending-capture-01.capture.json` | The first fixture: a reserved slot, `status: pending_capture`. No shot has been brewed. Acquisition instructions are in its `observations.notes` |
+
+## Naming
+
+`<YYYY-MM-DD>-<machine-slug>-<nn>.capture.json`, with the matching
+`<same-id>.telemetry.csv`. The `id` field must equal the filename stem.
+
+## Why this is not `assets/measured_shots/`
+
+`espressolab_cli calibrate` reads every `.json` in its shots directory as a
+measured shot, and a measured-shot document only carries what the fitter needs.
+A capture record carries the opposite: the full setup, the provenance, and an
+explicit list of what was **not** measured. Keeping the two apart is what stops
+a half-recorded shot from silently entering a fit.
+
+A capture is promoted into `assets/measured_shots/` only when every solver input
+is measured and non-null — see "Promoting a capture to a measured shot" in the
+validation doc.
+
+## The three statuses
+
+- `measured` — brewed and recorded under the capture protocol here. The only
+  status that may ever set `provenance.calibration_eligible`.
+- `external_public` — transcribed from a third-party public record. Check
+  `provenance.license` before redistributing anything; a null license forbids
+  vendoring the raw record.
+- `pending_capture` — a slot reserved by the protocol with no shot behind it.
+  Every observable is null, and the contract test fails if one is filled in.
+
+## The one rule
+
+Anything not measured stays `null`. Not `""`, not `"TBD"`, not an estimate, and
+never a value carried over from somewhere it does not belong — a machine
+temperature setpoint is not a measured brew temperature, and a grinder dial
+number is not a particle size.

--- a/assets/real_shots/TEMPLATE.capture.json
+++ b/assets/real_shots/TEMPLATE.capture.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": "1.0",
+  "kind": "real_shot_capture",
+  "id": "YYYY-MM-DD-<machine-slug>-<nn>",
+  "status": "pending_capture",
+
+  "capture": {
+    "utc_timestamp": null,
+    "operator": null,
+    "protocol_version": "1.0"
+  },
+
+  "provenance": {
+    "source": null,
+    "source_url": null,
+    "license": null,
+    "retrieved_at": null,
+    "data_quality_flags": [],
+    "calibration_eligible": false,
+    "validation_eligible": false
+  },
+
+  "machine": {
+    "model": null,
+    "firmware": null,
+    "basket": null,
+    "portafilter_diameter_mm": null,
+    "pressure_sensor_measures": null,
+    "pressure_sensor_location": null,
+    "temperature_sensor_location": null
+  },
+
+  "grinder": {
+    "model": null,
+    "burrs": null,
+    "dial_setting": null,
+    "rpm": null
+  },
+
+  "grind": {
+    "measured": false,
+    "method": null,
+    "d10_um": null,
+    "d50_um": null,
+    "d90_um": null,
+    "sauter_mean_d32_um": null,
+    "distribution": []
+  },
+
+  "coffee": {
+    "roaster": null,
+    "name": null,
+    "origin": null,
+    "process": null,
+    "roast_level": null,
+    "roast_date": null,
+    "days_off_roast": null,
+    "storage": null
+  },
+
+  "preparation": {
+    "dose_g": null,
+    "dose_scale_resolution_g": null,
+    "basket": null,
+    "distribution_technique": null,
+    "tamp": null,
+    "filter_paper": null,
+    "puck_screen": null,
+    "puck_depth_mm": null
+  },
+
+  "water": {
+    "recipe_name": null,
+    "source": null,
+    "tds_ppm": null,
+    "general_hardness_ppm_caco3": null,
+    "alkalinity_ppm_caco3": null
+  },
+
+  "temperature": {
+    "setpoint_c": null,
+    "measured_c": null,
+    "measurement_point": null,
+    "measurement_method": null,
+    "note": null
+  },
+
+  "pressure": {
+    "profile_name": null,
+    "profile_description": null,
+    "nominal_peak_bar": null,
+    "preinfusion": null
+  },
+
+  "timing": {
+    "convention": null,
+    "first_drip_s": null,
+    "end_condition": null,
+    "total_shot_time_s": null
+  },
+
+  "result": {
+    "beverage_yield_g": null,
+    "yield_scale_resolution_g": null,
+    "tds_percent": null,
+    "tds_method": {
+      "instrument": null,
+      "filtered": null,
+      "sample_temperature_c": null,
+      "repeats": null,
+      "readings_percent": []
+    },
+    "extraction_yield_percent": null,
+    "extraction_yield_source": null
+  },
+
+  "telemetry": {
+    "csv": null,
+    "columns": [],
+    "sample_rate_hz": null,
+    "row_count": null,
+    "time_origin": null
+  },
+
+  "observations": {
+    "taste": null,
+    "channeling": null,
+    "puck_condition": null,
+    "anomalies": [],
+    "notes": null
+  },
+
+  "attachments": {
+    "raw_shot_file": null,
+    "telemetry_csv": null,
+    "photos": [],
+    "video": null
+  },
+
+  "simulation_link": {
+    "recipe": null,
+    "unavailable_model_inputs": [],
+    "comparable_observables": []
+  }
+}

--- a/assets/real_shots/TEMPLATE.telemetry.csv
+++ b/assets/real_shots/TEMPLATE.telemetry.csv
@@ -1,0 +1,1 @@
+time_s,pressure_bar,flow_ml_s,cumulative_beverage_mass_g,temperature_c

--- a/docs/real-shot-validation.md
+++ b/docs/real-shot-validation.md
@@ -1,0 +1,147 @@
+# Real-shot validation
+
+Nothing in EspressoLab has been checked against a real espresso shot. The
+default coefficients are a plausible uncalibrated baseline, the measured-shot
+fixtures in `assets/measured_shots/` are solver output plus Gaussian noise, and
+`assets/reference_shots/` holds published *recipes*, not measurements. That gap
+is what this document addresses: where trustworthy real-shot data can come
+from, and a repeatable protocol for producing it.
+
+This document covers acquisition and validation. Fitting is separate and stays
+in [calibration.md](calibration.md) — see "Calibration is not validation" below.
+
+## Researched sources
+
+| Source | Contains | Lacks | Access / license | Parser testing | Chemistry reference | Calibration | Held-out validation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [Visualizer](https://visualizer.coffee/) shot API | Per-shot JSON: `timeframe` plus `data.espresso_pressure`, `espresso_flow`, `espresso_weight`, `espresso_flow_weight`, `espresso_temperature_basket`, `espresso_temperature_mix`, `espresso_resistance`, and the `*_goal` setpoint series; `bean_weight`, `drink_weight`, `drink_tds`, `drink_ey`, `grinder_model`, `grinder_setting`, `roast_date`, `roast_level`, free-text notes | **No machine model field**, no basket geometry, no puck depth, no PSD, no water recipe, no dose/yield scale resolution, no TDS method, no timing convention, no statement of whether the pressure series is pump or puck | Public shots readable anonymously (`GET /api/shots/<uuid>`, 200 requests / 10 min per IP). Shot data is user-submitted with **no stated reuse license** | **Yes — best available.** Real telemetry in a stable JSON shape | No | **No.** Heterogeneous across thousands of machines, baristas and unverified refractometers | Only after a specific shot's gaps are closed by contacting its author |
+| Visualizer [public compare example](https://visualizer.coffee/shots/7320f3a9-e2f6-4627-b745-b62c6d5f4d0d/compare/dbcaaa51-e830-4d54-9ae9-1494f78b6b8b) | Two shots, same coffee/grinder/setting: 20.1 g → 47.7 g in 72.8 s, TDS 10.94 %, EY 26.0 %; and 20.3 g → 47.7 g in 79.5 s, TDS 10.62 %, EY 25.0 %. 351-sample telemetry each | Same gaps as above. The web page's machine attribution is derived from free-text notes, not a field | Public, no stated license | Yes — the fixture this repo probed | Weak (n=2, one barista) | No | No |
+| [Coffee Ad Astra](https://www.patreon.com/coffeeadastra/posts/comparison-and-49666680) comparison post | Careful single-author extraction experiments, well-reasoned methodology | Post body is **not publicly retrievable** (HTTP 403 without a Patreon session); no machine-readable dataset is offered | Patron-only; all rights reserved | No | Background reading only | No | No |
+| [TUM / Mendeley dataset](https://data.mendeley.com/datasets/y2tz67f6ry/1) — Pannusch, Schmieder, Vannieuwenhuyse, Minceva, Briesen (TU München, 2023), DOI 10.17632/y2tz67f6ry.1 | MATLAB parameter-estimation code and an "Espresso Brewing Control App" for the kinetics model behind the Foods paper | It is **code, not the raw extraction data**; no shot telemetry | **CC BY-NC 3.0** — non-commercial only. Compatible with this repository only as a cited reference, not as vendored data | No | **Yes** — kinetic model structure for extraction of TDS and named compounds | No | No |
+| [Schmieder et al., *Foods* **12**(15):2871 (2023)](https://doi.org/10.3390/foods12152871), "Influence of Flow Rate, Particle Size, and Temperature on Espresso Extraction Kinetics" | Decent DE1 Pro (flow-controlled) + Mahlkönig E65S at three settings; laser-diffraction PSD (De Brouckere means 273–295 µm, Sauter means 26.9–29.2 µm); TDS by DR6000-T refractometer per DIN 10775; flow 1/2/3 ml·s⁻¹ × 80/89/98 °C central composite design; 20.00 ± 0.01 g dose; ten sequential fractions per extraction; 48 extractions | Per-shot telemetry time series are not published. **Data availability is "available from the corresponding author upon request"** — nothing downloadable | CC BY (gold open access) | No | **Yes — the strongest chemistry/extraction reference found.** Directly relevant to the extraction-rate and grind-factor correlations in [model.md](model.md) | Not as-is; the fractionated protocol is not a normal shot. Could become a calibration target only if the authors supply the raw data | No |
+
+### What this means
+
+- **No public source is ready to calibrate against.** Every candidate is missing
+  at least one input the solver requires: basket geometry, tamped puck depth, a
+  measured particle size distribution, or a measured brew-water temperature.
+- **Visualizer is the right target for import/parser work** and nothing more.
+  Its records are real, but a scalar dial setting and a machine-attributed
+  pressure series of unknown location cannot be turned into model inputs without
+  inventing numbers.
+- **The Foods paper is the right extraction-kinetics reference** and is properly
+  licensed to cite. The Mendeley companion is CC BY-NC, so its contents must not
+  be vendored into this repository.
+- **The strongest validation set has to be produced here**: several controlled
+  shots on one documented machine with the same coffee, water, basket and
+  preparation, varying one factor at a time. That is what the protocol below is
+  for.
+
+## Capture protocol 1.0
+
+One shot produces two files in `assets/real_shots/`:
+
+| File | Purpose |
+| --- | --- |
+| `<id>.capture.json` | Everything about the shot: setup, provenance, observations, and what was *not* measured |
+| `<id>.telemetry.csv` | The time series, columns exactly `time_s,pressure_bar,flow_ml_s,cumulative_beverage_mass_g,temperature_c` |
+
+Start from `TEMPLATE.capture.json` and `TEMPLATE.telemetry.csv`. The document
+format is specified by [`schemas/real-shot-capture.schema.json`](../schemas/real-shot-capture.schema.json)
+and enforced by `tests/schemas/real_shot_capture_check.py`.
+
+### Before the session
+
+1. Fix one machine, one coffee, one water recipe, one basket, one preparation
+   routine. Record them once; vary **only** grind across the session.
+2. Brew at least five shots. Reserve at least one, chosen before any fitting,
+   as a held-out validation shot.
+3. Decide the timing convention (`pump_on` or `first_drip`) and use it for both
+   the record and the CSV. Comparing a pump-on shot time against a first-drip
+   one is the easiest way to invent a two-second error.
+4. Establish what the machine's logged pressure actually measures — pump, group,
+   or puck. If you cannot establish it, record `unknown`. `unknown` is an
+   observation; a guess is not.
+
+### Per shot
+
+1. Weigh the dose and record the scale's resolution.
+2. Record the tamped bed depth (`preparation.puck_depth_mm`). No consumer
+   machine reports it and the solver needs it.
+3. Log telemetry if the machine can; otherwise leave `telemetry.csv` null. A
+   scale-only cumulative-mass trace is still worth having.
+4. Record `timing.first_drip_s`, `timing.end_condition` and
+   `timing.total_shot_time_s` against the chosen convention.
+5. Weigh the beverage; record the scale resolution.
+6. Measure TDS: let the sample cool to a stated temperature, syringe-filter it,
+   and take **repeated readings, all of them recorded** in
+   `result.tds_method.readings_percent`.
+7. Note taste, channelling, puck condition and any anomaly. Taste is logged, but
+   it is never a calibration target.
+
+### Rules the contract test enforces
+
+- Anything not measured is `null`. Never `""`, `"TBD"`, `"n/a"`, and never an
+  estimate.
+- A grinder dial setting is stored as **text** and is never converted to microns.
+  PSD numbers require `grind.measured: true` and a stated `grind.method`.
+- `temperature.setpoint_c` is what the machine was told to do;
+  `temperature.measured_c` requires a measurement point and method.
+- `machine.pressure_sensor_measures` is mandatory whenever telemetry exists.
+- A `computed` extraction yield must equal `tds × yield ÷ dose` to within
+  0.05 percentage points.
+- `telemetry.time_origin` must equal `timing.convention`.
+- If `simulation_link.unavailable_model_inputs` is non-empty,
+  `simulation_link.recipe` stays null: the shot is not simulable without
+  inventing a number.
+- A `pending_capture` record carries no observations at all.
+
+## Comparing a capture against a simulation
+
+Only the entries listed in `simulation_link.comparable_observables` may be
+scored, and only against a simulation whose inputs came from the same record in
+the same units.
+
+| Scalar | Report |
+| --- | --- |
+| `beverage_yield_g`, `total_shot_time_s`, `first_drip_s`, `tds_percent`, `extraction_yield_percent` | Absolute error, in the observable's own unit |
+
+| Curve | Report |
+| --- | --- |
+| pressure, flow, temperature, cumulative mass | MAE and RMSE — **only** when the measured and simulated series share a time origin. If they do not, resample or report nothing |
+
+Two traps worth naming, because the model invites both:
+
+- Pressure is a recipe *input* to this solver, not a prediction. A pressure RMSE
+  is a diagnostic that the machine followed its profile, not a model score.
+- The solver's sampled flow is Darcy flow *into the bed*; a scale measures mass
+  *out of the spout*. They differ until the pores fill. Compare cumulative mass,
+  or accept the offset explicitly.
+
+## Calibration is not validation
+
+- Validation scores a fixed coefficient set against shots. Calibration changes
+  the coefficients. Never report a fit's own loss as validation.
+- Fit a small, physically interpretable coefficient set across several shots —
+  not one shot exactly. `--leave-one-out` exists for exactly this
+  (`assets/measured_shots/README.md`).
+- At least one shot is held out and never fitted on, and is named in the
+  coefficient file's `provenance`.
+- Any coefficient set fitted to real shots must record dataset identity, fit
+  date, machine, known limitations and provenance, so a later re-fit never
+  silently changes what a past run meant.
+
+## Promoting a capture to a measured shot
+
+`assets/real_shots/` is inert: nothing in the build reads it, and
+`espressolab_cli calibrate` never sees it. A capture becomes usable by the
+fitter only when every solver input is present and non-null — dose, basket
+diameter, puck depth, an effective particle size or PSD, and the brew
+temperature — at which point it is transcribed into a measured-shot document in
+`assets/measured_shots/` with `synthetic: false`. The capture record stays
+behind as its provenance.
+
+`espressolab_cli calibrate` reads **every** `.json` in its shots directory as a
+measured shot, which is why capture records live in their own directory and use
+the `.capture.json` suffix. The contract test fails if one appears in
+`assets/measured_shots/`.

--- a/schemas/real-shot-capture.schema.json
+++ b/schemas/real-shot-capture.schema.json
@@ -1,0 +1,280 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://espressolab.local/schemas/real-shot-capture-1.0.json",
+  "title": "EspressoLab real-shot capture record",
+  "description": "One physically brewed espresso shot, recorded for validating the simulator against reality. Deliberately NOT the measured-shot document that `espressolab_cli calibrate` reads (assets/measured_shots/, engine/calibration/calibration_io.cpp): a capture record describes the shot and its provenance in full, including everything the machine did not measure. A capture is promoted to a measured shot only after the fields the solver needs are all present and non-null.",
+  "$comment": "Kept synchronized with tests/schemas/real_shot_capture_check.py, which is the executable contract (stdlib-only, run in CI). Missing values are ALWAYS null, never a placeholder string and never an estimate. See docs/real-shot-validation.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "kind", "id", "status", "capture", "provenance", "machine", "grinder", "grind", "coffee", "preparation", "water", "temperature", "pressure", "timing", "result", "telemetry", "observations", "attachments", "simulation_link"],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "kind": { "const": "real_shot_capture" },
+    "id": {
+      "type": "string", "minLength": 1,
+      "description": "Stable shot ID. Convention: YYYY-MM-DD-<machine-slug>-<nn>."
+    },
+    "status": {
+      "enum": ["measured", "external_public", "pending_capture"],
+      "description": "`measured` = brewed and recorded under this repository's protocol. `external_public` = transcribed from a public third-party record; check `provenance.license` before redistributing. `pending_capture` = a slot reserved by the protocol with no shot brewed yet; every observable is null."
+    },
+
+    "capture": {
+      "type": "object", "additionalProperties": false,
+      "required": ["utc_timestamp", "operator", "protocol_version"],
+      "properties": {
+        "utc_timestamp": {
+          "type": ["string", "null"],
+          "description": "RFC 3339 UTC instant the shot started (pump-on), e.g. 2026-09-01T08:14:03Z. Null only while status is pending_capture."
+        },
+        "operator": { "type": ["string", "null"] },
+        "protocol_version": { "type": "string", "description": "Version of the capture protocol in docs/real-shot-validation.md that this shot followed." }
+      }
+    },
+
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "source_url", "license", "retrieved_at", "data_quality_flags", "calibration_eligible", "validation_eligible"],
+      "properties": {
+        "source": { "type": ["string", "null"], "description": "Who produced the numbers, e.g. 'first-party capture' or 'visualizer.coffee'." },
+        "source_url": { "type": ["string", "null"] },
+        "license": { "type": ["string", "null"], "description": "Verbatim license of the underlying data. Null means unknown, which forbids redistribution of the raw record." },
+        "retrieved_at": { "type": ["string", "null"] },
+        "data_quality_flags": {
+          "type": "array", "items": { "type": "string" },
+          "description": "Known defects, e.g. 'pressure sensor measures pump not puck', 'single TDS reading', 'grind setting is a dial number, no PSD'."
+        },
+        "calibration_eligible": { "type": "boolean", "description": "May this shot be used to FIT coefficients? Never true for external_public or pending_capture." },
+        "validation_eligible": { "type": "boolean", "description": "May this shot be scored as a held-out validation case? Mutually exclusive with calibration_eligible for any one fit." }
+      }
+    },
+
+    "machine": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model", "firmware", "basket", "portafilter_diameter_mm", "pressure_sensor_measures", "pressure_sensor_location", "temperature_sensor_location"],
+      "properties": {
+        "model": { "type": ["string", "null"] },
+        "firmware": { "type": ["string", "null"] },
+        "basket": { "type": ["string", "null"], "description": "Basket make, nominal dose and hole pattern, e.g. 'VST 18 g ridgeless'." },
+        "portafilter_diameter_mm": { "type": ["number", "null"], "minimum": 30, "maximum": 90 },
+        "pressure_sensor_measures": {
+          "enum": ["pump", "group", "puck", "unknown", null],
+          "description": "Pump pressure is not puck pressure. Recording which one was logged is mandatory; `unknown` is an honest answer, a guess is not."
+        },
+        "pressure_sensor_location": { "type": ["string", "null"] },
+        "temperature_sensor_location": {
+          "type": ["string", "null"],
+          "description": "Physical location of the logged temperature probe, e.g. 'group head thermofilter, 2 mm above shower screen'. A boiler or PID setpoint is NOT a sensor location."
+        }
+      }
+    },
+
+    "grinder": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model", "burrs", "dial_setting", "rpm"],
+      "properties": {
+        "model": { "type": ["string", "null"] },
+        "burrs": { "type": ["string", "null"] },
+        "dial_setting": {
+          "type": ["string", "null"],
+          "description": "Recorded verbatim as text, e.g. '6.5 @ 1500 rpm'. A string on purpose: a dial number is not a length and must never be converted into microns."
+        },
+        "rpm": { "type": ["number", "null"] }
+      }
+    },
+
+    "grind": {
+      "type": "object", "additionalProperties": false,
+      "required": ["measured", "method", "d10_um", "d50_um", "d90_um", "sauter_mean_d32_um", "distribution"],
+      "properties": {
+        "measured": { "type": "boolean", "description": "True only if a particle size distribution was physically measured for THIS grind setting." },
+        "method": { "type": ["string", "null"], "description": "e.g. 'laser diffraction, wet dispersion, Malvern Mastersizer 3000'. Required whenever measured is true." },
+        "d10_um": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "d50_um": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "d90_um": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "sauter_mean_d32_um": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "distribution": {
+          "type": "array",
+          "description": "Binned PSD in the same shape as a recipe's puck.grind, so a measured grind can be fed to the solver without reinterpretation. Empty when nothing was measured.",
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["diameter_um", "mass_fraction"],
+            "properties": {
+              "diameter_um": { "type": "number", "exclusiveMinimum": 0 },
+              "mass_fraction": { "type": "number", "minimum": 0, "maximum": 1 }
+            }
+          }
+        }
+      }
+    },
+
+    "coffee": {
+      "type": "object", "additionalProperties": false,
+      "required": ["roaster", "name", "origin", "process", "roast_level", "roast_date", "days_off_roast", "storage"],
+      "properties": {
+        "roaster": { "type": ["string", "null"] },
+        "name": { "type": ["string", "null"] },
+        "origin": { "type": ["string", "null"] },
+        "process": { "type": ["string", "null"] },
+        "roast_level": { "type": ["string", "null"] },
+        "roast_date": { "type": ["string", "null"], "description": "ISO date. Never inferred from a bag photo or a purchase date." },
+        "days_off_roast": { "type": ["integer", "null"], "minimum": 0 },
+        "storage": { "type": ["string", "null"], "description": "e.g. 'one-way valve bag, sealed, 21 C, opened 4 days before'." }
+      }
+    },
+
+    "preparation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["dose_g", "dose_scale_resolution_g", "basket", "distribution_technique", "tamp", "filter_paper", "puck_screen", "puck_depth_mm"],
+      "properties": {
+        "dose_g": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "dose_scale_resolution_g": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "basket": { "type": ["string", "null"] },
+        "distribution_technique": { "type": ["string", "null"], "description": "e.g. 'WDT 8 needles, 20 s, then levelled'." },
+        "tamp": { "type": ["string", "null"] },
+        "filter_paper": { "type": ["string", "null"], "description": "Below-puck paper filter, or null if none used." },
+        "puck_screen": { "type": ["string", "null"] },
+        "puck_depth_mm": {
+          "type": ["number", "null"], "exclusiveMinimum": 0,
+          "description": "Tamped bed depth. A solver input the machine never reports -- measure it (basket depth minus headspace) or leave it null."
+        }
+      }
+    },
+
+    "water": {
+      "type": "object", "additionalProperties": false,
+      "required": ["recipe_name", "source", "tds_ppm", "general_hardness_ppm_caco3", "alkalinity_ppm_caco3"],
+      "properties": {
+        "recipe_name": { "type": ["string", "null"], "description": "e.g. 'Rao/Perger Ideal', 'third-wave water espresso profile', 'municipal, unfiltered'." },
+        "source": { "type": ["string", "null"] },
+        "tds_ppm": { "type": ["number", "null"], "minimum": 0 },
+        "general_hardness_ppm_caco3": { "type": ["number", "null"], "minimum": 0 },
+        "alkalinity_ppm_caco3": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+
+    "temperature": {
+      "type": "object", "additionalProperties": false,
+      "required": ["setpoint_c", "measured_c", "measurement_point", "measurement_method", "note"],
+      "properties": {
+        "setpoint_c": {
+          "type": ["number", "null"], "minimum": 0, "maximum": 130,
+          "description": "What the machine was told to do. NOT an observation: never copy this into measured_c."
+        },
+        "measured_c": {
+          "type": ["number", "null"], "minimum": 0, "maximum": 130,
+          "description": "Physically measured brew-water temperature. Non-null requires measurement_point and measurement_method."
+        },
+        "measurement_point": { "type": ["string", "null"] },
+        "measurement_method": { "type": ["string", "null"] },
+        "note": { "type": ["string", "null"] }
+      }
+    },
+
+    "pressure": {
+      "type": "object", "additionalProperties": false,
+      "required": ["profile_name", "profile_description", "nominal_peak_bar", "preinfusion"],
+      "properties": {
+        "profile_name": { "type": ["string", "null"] },
+        "profile_description": { "type": ["string", "null"], "description": "The commanded profile in words. The telemetry CSV carries what actually happened." },
+        "nominal_peak_bar": { "type": ["number", "null"], "minimum": 0, "maximum": 20 },
+        "preinfusion": { "type": ["string", "null"] }
+      }
+    },
+
+    "timing": {
+      "type": "object", "additionalProperties": false,
+      "required": ["convention", "first_drip_s", "end_condition", "total_shot_time_s"],
+      "properties": {
+        "convention": {
+          "enum": ["pump_on", "first_drip", "other", null],
+          "description": "What t=0 means, for both this record and the telemetry CSV. Comparing a pump-on shot time against a first-drip one is the single easiest way to invent a two-second error."
+        },
+        "first_drip_s": { "type": ["number", "null"], "minimum": 0 },
+        "end_condition": { "type": ["string", "null"], "description": "e.g. 'stopped by scale at 36.0 g target', 'stopped by hand at 30 s'." },
+        "total_shot_time_s": { "type": ["number", "null"], "exclusiveMinimum": 0 }
+      }
+    },
+
+    "result": {
+      "type": "object", "additionalProperties": false,
+      "required": ["beverage_yield_g", "yield_scale_resolution_g", "tds_percent", "tds_method", "extraction_yield_percent", "extraction_yield_source"],
+      "properties": {
+        "beverage_yield_g": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "yield_scale_resolution_g": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "tds_percent": { "type": ["number", "null"], "minimum": 0, "maximum": 30 },
+        "tds_method": {
+          "type": "object", "additionalProperties": false,
+          "required": ["instrument", "filtered", "sample_temperature_c", "repeats", "readings_percent"],
+          "properties": {
+            "instrument": { "type": ["string", "null"] },
+            "filtered": { "type": ["boolean", "null"], "description": "Whether the sample was syringe-filtered before reading. Unfiltered espresso reads high." },
+            "sample_temperature_c": { "type": ["number", "null"], "minimum": 0, "maximum": 100 },
+            "repeats": { "type": ["integer", "null"], "minimum": 1 },
+            "readings_percent": { "type": "array", "items": { "type": "number" }, "description": "Every individual reading, not just the mean." }
+          }
+        },
+        "extraction_yield_percent": { "type": ["number", "null"], "minimum": 0, "maximum": 40 },
+        "extraction_yield_source": {
+          "enum": ["computed", "measured", null],
+          "description": "`computed` = tds_percent * beverage_yield_g / dose_g, checked by the contract test. `measured` = the cup was dried and weighed."
+        }
+      }
+    },
+
+    "telemetry": {
+      "type": "object", "additionalProperties": false,
+      "required": ["csv", "columns", "sample_rate_hz", "row_count", "time_origin"],
+      "properties": {
+        "csv": { "type": ["string", "null"], "description": "Path relative to this file. Null when no telemetry was logged." },
+        "columns": {
+          "type": "array", "items": { "type": "string" },
+          "description": "Must be exactly the target column set when csv is non-null."
+        },
+        "sample_rate_hz": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "row_count": { "type": ["integer", "null"], "minimum": 0 },
+        "time_origin": { "enum": ["pump_on", "first_drip", "other", null], "description": "Must equal timing.convention." }
+      }
+    },
+
+    "observations": {
+      "type": "object", "additionalProperties": false,
+      "required": ["taste", "channeling", "puck_condition", "anomalies", "notes"],
+      "properties": {
+        "taste": { "type": ["string", "null"], "description": "Recorded for the log only. Taste is never a calibration target (assets/measured_shots/README.md)." },
+        "channeling": { "type": ["string", "null"] },
+        "puck_condition": { "type": ["string", "null"] },
+        "anomalies": { "type": "array", "items": { "type": "string" } },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+
+    "attachments": {
+      "type": "object", "additionalProperties": false,
+      "required": ["raw_shot_file", "telemetry_csv", "photos", "video"],
+      "properties": {
+        "raw_shot_file": { "type": ["string", "null"], "description": "Untouched machine export (Decent .shot, Visualizer JSON, Gaggiuino CSV) kept verbatim beside the record." },
+        "telemetry_csv": { "type": ["string", "null"], "description": "Same path as telemetry.csv; repeated here so the attachment list is complete." },
+        "photos": { "type": "array", "items": { "type": "string" } },
+        "video": { "type": ["string", "null"] }
+      }
+    },
+
+    "simulation_link": {
+      "type": "object", "additionalProperties": false,
+      "required": ["recipe", "unavailable_model_inputs", "comparable_observables"],
+      "properties": {
+        "recipe": { "type": ["string", "null"], "description": "Path to the EspressoLab recipe that reproduces this shot's inputs. Null until every required model input is measured." },
+        "unavailable_model_inputs": {
+          "type": "array", "items": { "type": "string" },
+          "description": "Solver inputs this capture cannot supply. Non-empty means the shot is not simulable without inventing a number, so `recipe` stays null."
+        },
+        "comparable_observables": {
+          "type": "array",
+          "items": { "enum": ["beverage_yield_g", "total_shot_time_s", "first_drip_s", "tds_percent", "extraction_yield_percent", "pressure_curve", "flow_curve", "temperature_curve", "cumulative_mass_curve"] },
+          "description": "Exactly what may be scored against a simulation. Curve entries are permitted only when the telemetry CSV shares timing.convention with the simulation."
+        }
+      }
+    }
+  }
+}

--- a/tests/schemas/real_shot_capture_check.py
+++ b/tests/schemas/real_shot_capture_check.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Contract check for real-shot capture records (assets/real_shots/*.capture.json).
+
+The point of a capture record is that it does not lie about what was measured,
+so this checks the rules that a JSON Schema cannot express and that a careless
+capture would silently break:
+
+  - every field present, missing values held as null (never "", "TBD", "n/a")
+  - a pending_capture record contains no observations at all
+  - a grinder dial setting stays a string; PSD numbers require a measurement
+  - a temperature setpoint is never presented as a measured temperature
+  - pump pressure and puck pressure are distinguished explicitly
+  - a computed extraction yield actually equals tds * yield / dose
+  - telemetry columns and time origin match the target contract and timing
+  - capture records never leak into assets/measured_shots/, which
+    `espressolab_cli calibrate` reads wholesale
+
+Stdlib only (unlike tests/schemas/schema_contract_check.py, which needs the
+unvendored `jsonschema` package), so CI can run it:
+
+    python3 tests/schemas/real_shot_capture_check.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+TELEMETRY_COLUMNS = [
+    "time_s",
+    "pressure_bar",
+    "flow_ml_s",
+    "cumulative_beverage_mass_g",
+    "temperature_c",
+]
+
+# A capture record says "not measured" with null. These strings are the usual
+# ways a hand-filled form pretends to carry a value instead.
+PLACEHOLDERS = {"", "tbd", "todo", "n/a", "na", "none", "unknown", "?", "-", "null"}
+
+REQUIRED = {
+    None: ["schema_version", "kind", "id", "status", "capture", "provenance", "machine",
+           "grinder", "grind", "coffee", "preparation", "water", "temperature", "pressure",
+           "timing", "result", "telemetry", "observations", "attachments", "simulation_link"],
+    "capture": ["utc_timestamp", "operator", "protocol_version"],
+    "provenance": ["source", "source_url", "license", "retrieved_at", "data_quality_flags",
+                   "calibration_eligible", "validation_eligible"],
+    "machine": ["model", "firmware", "basket", "portafilter_diameter_mm",
+                "pressure_sensor_measures", "pressure_sensor_location",
+                "temperature_sensor_location"],
+    "grinder": ["model", "burrs", "dial_setting", "rpm"],
+    "grind": ["measured", "method", "d10_um", "d50_um", "d90_um", "sauter_mean_d32_um",
+              "distribution"],
+    "coffee": ["roaster", "name", "origin", "process", "roast_level", "roast_date",
+               "days_off_roast", "storage"],
+    "preparation": ["dose_g", "dose_scale_resolution_g", "basket", "distribution_technique",
+                    "tamp", "filter_paper", "puck_screen", "puck_depth_mm"],
+    "water": ["recipe_name", "source", "tds_ppm", "general_hardness_ppm_caco3",
+              "alkalinity_ppm_caco3"],
+    "temperature": ["setpoint_c", "measured_c", "measurement_point", "measurement_method", "note"],
+    "pressure": ["profile_name", "profile_description", "nominal_peak_bar", "preinfusion"],
+    "timing": ["convention", "first_drip_s", "end_condition", "total_shot_time_s"],
+    "result": ["beverage_yield_g", "yield_scale_resolution_g", "tds_percent", "tds_method",
+               "extraction_yield_percent", "extraction_yield_source"],
+    "telemetry": ["csv", "columns", "sample_rate_hz", "row_count", "time_origin"],
+    "observations": ["taste", "channeling", "puck_condition", "anomalies", "notes"],
+    "attachments": ["raw_shot_file", "telemetry_csv", "photos", "video"],
+    "simulation_link": ["recipe", "unavailable_model_inputs", "comparable_observables"],
+}
+
+CURVE_OBSERVABLES = {"pressure_curve", "flow_curve", "temperature_curve",
+                     "cumulative_mass_curve"}
+
+
+def check_record(path: Path, record: dict) -> list[str]:
+    errors: list[str] = []
+
+    def fail(message: str):
+        errors.append(f"{path.name}: {message}")
+
+    for section, keys in REQUIRED.items():
+        node = record if section is None else record.get(section)
+        if not isinstance(node, dict):
+            fail(f"{section or 'document'} must be an object")
+            continue
+        for key in keys:
+            if key not in node:
+                fail(f"missing field {section + '.' if section else ''}{key}")
+
+    if errors:
+        return errors  # Later rules assume the shape is there.
+
+    if record["schema_version"] != "1.0":
+        fail(f"schema_version {record['schema_version']!r} is not supported (expected '1.0')")
+    if record["kind"] != "real_shot_capture":
+        fail(f"kind must be 'real_shot_capture', got {record['kind']!r}")
+    status = record["status"]
+    if status not in ("measured", "external_public", "pending_capture"):
+        fail(f"status {status!r} is not one of measured/external_public/pending_capture")
+    if record["id"] != path.name.removesuffix(".capture.json"):
+        fail(f"id {record['id']!r} does not match the filename")
+
+    # Missing means null. A placeholder string is a fabricated value that reads
+    # as data downstream.
+    def walk(node, trail):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, f"{trail}.{key}" if trail else key)
+        elif isinstance(node, list):
+            for i, value in enumerate(node):
+                walk(value, f"{trail}[{i}]")
+        elif isinstance(node, str) and node.strip().lower() in PLACEHOLDERS:
+            fail(f"{trail} is the placeholder {node!r}; record an unmeasured value as null")
+
+    walk(record, "")
+
+    provenance = record["provenance"]
+    if status != "measured" and provenance["calibration_eligible"]:
+        fail(f"calibration_eligible must be false while status is {status!r}")
+    if status == "pending_capture" and provenance["validation_eligible"]:
+        fail("validation_eligible must be false until the shot is actually brewed")
+
+    # A dial number is not a length. Keeping it typed as text is what stops it
+    # from being read as microns.
+    dial = record["grinder"]["dial_setting"]
+    if dial is not None and not isinstance(dial, str):
+        fail("grinder.dial_setting must be a string; a dial number is not a particle size")
+
+    grind = record["grind"]
+    psd_numbers = ["d10_um", "d50_um", "d90_um", "sauter_mean_d32_um"]
+    has_psd = any(grind[key] is not None for key in psd_numbers) or bool(grind["distribution"])
+    if has_psd and not grind["measured"]:
+        fail("grind carries particle sizes but grind.measured is false; PSD is never derived "
+             "from a grinder dial setting")
+    if grind["measured"] and grind["method"] is None:
+        fail("grind.measured is true but grind.method does not say how it was measured")
+    total = sum(bin_["mass_fraction"] for bin_ in grind["distribution"])
+    if grind["distribution"] and abs(total - 1.0) > 1e-6:
+        fail(f"grind.distribution mass fractions sum to {total}, not 1")
+
+    temperature = record["temperature"]
+    if temperature["measured_c"] is not None:
+        if temperature["measurement_point"] is None or temperature["measurement_method"] is None:
+            fail("temperature.measured_c requires measurement_point and measurement_method; a "
+                 "boiler setpoint is not a measured brew temperature")
+        if temperature["setpoint_c"] is not None and record["status"] == "pending_capture":
+            fail("a pending_capture record must not carry a measured temperature")
+
+    sensor = record["machine"]["pressure_sensor_measures"]
+    if sensor not in ("pump", "group", "puck", "unknown", None):
+        fail(f"machine.pressure_sensor_measures {sensor!r} must be pump/group/puck/unknown/null")
+    if record["telemetry"]["csv"] is not None and sensor is None:
+        fail("telemetry carries a pressure column but machine.pressure_sensor_measures is null; "
+             "pump pressure is not puck pressure")
+
+    result = record["result"]
+    dose = record["preparation"]["dose_g"]
+    tds = result["tds_percent"]
+    yield_g = result["beverage_yield_g"]
+    ey = result["extraction_yield_percent"]
+    if ey is not None and result["extraction_yield_source"] is None:
+        fail("extraction_yield_percent requires extraction_yield_source (computed or measured)")
+    if result["extraction_yield_source"] == "computed":
+        if None in (dose, tds, yield_g, ey):
+            fail("a computed extraction yield needs dose_g, tds_percent, beverage_yield_g and "
+                 "extraction_yield_percent")
+        else:
+            expected = tds * yield_g / dose
+            if abs(expected - ey) > 0.05:
+                fail(f"extraction_yield_percent {ey} does not match tds*yield/dose "
+                     f"({expected:.3f}) within 0.05 percentage points")
+    readings = result["tds_method"]["readings_percent"]
+    repeats = result["tds_method"]["repeats"]
+    if readings and repeats is not None and len(readings) != repeats:
+        fail(f"tds_method has {len(readings)} readings but claims {repeats} repeats")
+    if tds is not None and not readings:
+        fail("tds_percent is recorded but tds_method.readings_percent is empty; keep every reading")
+
+    telemetry = record["telemetry"]
+    if telemetry["csv"] is not None:
+        if telemetry["columns"] != TELEMETRY_COLUMNS:
+            fail(f"telemetry.columns must be exactly {TELEMETRY_COLUMNS}")
+        if telemetry["time_origin"] != record["timing"]["convention"]:
+            fail("telemetry.time_origin must equal timing.convention; a curve compared across "
+                 "two different t=0 conventions is not time-aligned")
+        csv_path = (path.parent / telemetry["csv"]).resolve()
+        if not csv_path.is_file():
+            fail(f"telemetry.csv points at missing file {telemetry['csv']}")
+        else:
+            header = csv_path.read_text().splitlines()[0].strip()
+            if header != ",".join(TELEMETRY_COLUMNS):
+                fail(f"{telemetry['csv']} header is {header!r}, expected "
+                     f"{','.join(TELEMETRY_COLUMNS)}")
+        if telemetry["csv"] != record["attachments"]["telemetry_csv"]:
+            fail("attachments.telemetry_csv must repeat telemetry.csv")
+    elif telemetry["columns"] or telemetry["row_count"]:
+        fail("telemetry has columns or rows but no csv file")
+
+    link = record["simulation_link"]
+    observables = link["comparable_observables"]
+    if link["recipe"] is None and observables:
+        fail("comparable_observables is non-empty but no recipe reproduces this shot's inputs")
+    if link["unavailable_model_inputs"] and link["recipe"] is not None:
+        fail("simulation_link names unavailable model inputs, so recipe must stay null rather "
+             "than invent them")
+    if CURVE_OBSERVABLES & set(observables) and telemetry["csv"] is None:
+        fail("a curve observable requires a time-aligned telemetry CSV")
+
+    if status == "pending_capture":
+        observed = {
+            "capture.utc_timestamp": record["capture"]["utc_timestamp"],
+            "preparation.dose_g": record["preparation"]["dose_g"],
+            "timing.total_shot_time_s": record["timing"]["total_shot_time_s"],
+            "timing.first_drip_s": record["timing"]["first_drip_s"],
+            "result.beverage_yield_g": yield_g,
+            "result.tds_percent": tds,
+            "result.extraction_yield_percent": ey,
+            "temperature.measured_c": temperature["measured_c"],
+            "telemetry.csv": telemetry["csv"],
+        }
+        for field, value in observed.items():
+            if value is not None:
+                fail(f"status is pending_capture but {field} carries a value ({value!r}); no "
+                     "shot has been brewed")
+
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    capture_dir = root / "assets" / "real_shots"
+
+    records = sorted(path for path in capture_dir.glob("*.capture.json")
+                     if path.name != "TEMPLATE.capture.json")
+    if not records:
+        print(f"FAIL: no capture records found in {capture_dir}")
+        return 1
+    records.append(capture_dir / "TEMPLATE.capture.json")
+
+    errors: list[str] = []
+    for path in records:
+        try:
+            record = json.loads(path.read_text())
+        except json.JSONDecodeError as e:
+            errors.append(f"{path.name}: not valid JSON ({e})")
+            continue
+        if path.name == "TEMPLATE.capture.json":
+            # The template is checked for shape, not for its placeholder id.
+            record = dict(record, id=path.name.removesuffix(".capture.json"))
+        errors.extend(check_record(path, record))
+
+    template_header = (capture_dir / "TEMPLATE.telemetry.csv").read_text().splitlines()[0].strip()
+    if template_header != ",".join(TELEMETRY_COLUMNS):
+        errors.append(f"TEMPLATE.telemetry.csv header is {template_header!r}")
+
+    # `espressolab_cli calibrate` reads every .json in its directory as a
+    # measured shot, so a capture record dropped there would break the fit.
+    for stray in (root / "assets" / "measured_shots").glob("*.capture.json"):
+        errors.append(f"{stray.name}: capture records must not live in assets/measured_shots/")
+
+    for error in errors:
+        print(f"FAIL {error}")
+    checked = len(records)
+    if errors:
+        print(f"\n{len(errors)} problem(s) across {checked} capture record(s)")
+        return 1
+    print(f"OK: {checked} capture record(s) satisfy the real-shot capture contract")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Nothing in EspressoLab has been checked against a real espresso shot. The default coefficients are uncalibrated, `assets/measured_shots/` holds solver output plus Gaussian noise, and `assets/reference_shots/` holds published *recipes* rather than measurements. This PR adds the acquisition side of closing that gap: a researched view of where real data can come from, a repeatable capture protocol, and the first fixture.

**No measured value is fabricated anywhere in this change.**

## Source research

Full write-up in `docs/real-shot-validation.md`.

| Source | Verdict |
| --- | --- |
| [Visualizer](https://visualizer.coffee/) API | **Best parser/import target.** Public shots readable anonymously (`GET /api/shots/<uuid>`, 200 req/10 min/IP) with real telemetry: pressure, flow, weight, basket/mix temperature, plus `*_goal` setpoints. But **no machine model field**, no basket geometry, puck depth, PSD, water recipe, TDS method, timing convention, or pump-vs-puck pressure statement — and user-submitted shots carry **no stated reuse license**. Not usable for calibration. |
| Visualizer [compare example](https://visualizer.coffee/shots/7320f3a9-e2f6-4627-b745-b62c6d5f4d0d/compare/dbcaaa51-e830-4d54-9ae9-1494f78b6b8b) | 20.1 g→47.7 g / 72.8 s / TDS 10.94 % / EY 26.0 %, and 20.3 g→47.7 g / 79.5 s / TDS 10.62 % / EY 25.0 %; 351 telemetry samples each. Same gaps. Note the web page's machine attribution comes from free-text notes, not a field. |
| [Coffee Ad Astra](https://www.patreon.com/coffeeadastra/posts/comparison-and-49666680) | **Not publicly retrievable** (HTTP 403 without a Patreon session); no machine-readable data. Patron-only, all rights reserved. |
| [TUM / Mendeley `y2tz67f6ry`](https://data.mendeley.com/datasets/y2tz67f6ry/1) | MATLAB parameter-estimation code and a brewing-control app — **code, not the raw extraction data**. **CC BY-NC 3.0**, so citable but must not be vendored here. |
| [Schmieder et al., *Foods* 12(15):2871](https://doi.org/10.3390/foods12152871) | **Strongest extraction-kinetics reference.** DE1 Pro + Mahlkönig E65S; laser-diffraction PSD (De Brouckere 273–295 µm, Sauter 26.9–29.2 µm); TDS by DR6000-T per DIN 10775; flow 1/2/3 ml/s × 80/89/98 °C CCD; 20.00 ± 0.01 g; 10 fractions/run; 48 extractions. CC BY. But per-shot telemetry is unpublished and data is "available from the corresponding author upon request". |

**Conclusion:** no public source can calibrate against today — each is missing at least one required solver input (basket geometry, tamped puck depth, measured PSD, or measured brew temperature). The strongest validation set has to be produced here: several controlled shots on one documented machine, same coffee/water/basket/preparation, varying one factor at a time.

## What this adds

- `schemas/real-shot-capture.schema.json` — the capture document format.
- `assets/real_shots/TEMPLATE.capture.json` + `TEMPLATE.telemetry.csv` — copy-per-shot templates. Telemetry columns are exactly `time_s,pressure_bar,flow_ml_s,cumulative_beverage_mass_g,temperature_c`.
- `assets/real_shots/2026-09-01-pending-capture-01.capture.json` — **the first fixture**, `status: pending_capture`. Every observable is null; acquisition instructions live in `observations.notes`; `simulation_link.unavailable_model_inputs` names the three blockers (PSD, puck depth, measured inlet temperature).
- `docs/real-shot-validation.md` — sources, capture protocol 1.0, comparison rules, and the promotion path into `assets/measured_shots/`.
- `tests/schemas/real_shot_capture_check.py` — the executable contract, wired into CI.

### Why a new `assets/real_shots/` directory

`espressolab_cli calibrate` reads **every** `.json` in its shots directory as a measured shot. A pending or half-recorded capture dropped into `assets/measured_shots/` would silently enter a fit. Captures therefore live in their own directory with a `.capture.json` suffix, and the contract test fails if one appears in the calibrate directory. The directory is inert — no build, solver, server, or calibration path reads it.

### What the contract test enforces

Stdlib only, unlike `schema_contract_check.py` (which needs the unvendored `jsonschema` package), so CI can actually run it. It covers the rules a JSON Schema cannot express:

- Unmeasured values stay `null` — never `""`, `"TBD"`, `"n/a"`, never an estimate.
- A grinder dial setting stays **text** and is never converted to microns; PSD numbers require `grind.measured: true` and a stated method.
- A temperature **setpoint** is never presented as a **measured** temperature.
- Pump, group, and puck pressure are distinguished explicitly; mandatory whenever telemetry exists.
- A `computed` extraction yield equals `tds × yield ÷ dose` within 0.05 pp.
- `telemetry.time_origin` equals `timing.convention` — a curve compared across two different `t=0` conventions is not time-aligned.
- A `pending_capture` record carries no observations at all.

## Verification

- `python3 tests/schemas/real_shot_capture_check.py` → OK, 2 records.
- Nine sandboxed mutations, one per rule above, all rejected.
- Both fixtures validate against the new schema with `jsonschema` Draft 2020-12.
- `tests/schemas/schema_contract_check.py` → still 18/18, no regression from the added schema.
- `./build/tests/espressolab_tests "[calibration]"` → 109 assertions in 24 cases, all pass.
- `grep` confirms nothing reads `assets/real_shots/`; CI YAML parses.

No solver, artifact, hash, or dashboard code is touched, so reproducibility is unaffected.

## Scope

Bounded deliberately. No importer, no calibration run, no dashboard work, no claim of real-world validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sURXhyZPDeEEgD2PzkUv4
