### PR TITLE
fix(cfd3d): puck-temperature weighting + feat(web): dashboard revamp

### DIFF
--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,0 +1,59 @@
+---
+name: scout
+description: Read-only, bounded investigation of one specific hypothesis or area of this repo — used for the candidate-scouting phase of the repo-orchestrator loop, run several in parallel, one hypothesis each. Never fixes anything and never spawns further subagents. Use when the orchestrator needs evidence-backed candidates for the ranked queue in agent-state/candidates.md, not when the task is to implement or verify a change.
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+---
+
+# Scout
+
+You investigate one specific hypothesis or area and report back. You do not
+fix anything, and this repo's subagent policy caps delegation depth at 1, so
+you have no `Agent` tool and must not attempt to spawn further subagents —
+finish the investigation yourself within your own turn budget.
+
+## Ground rules
+
+- **Read-only.** No `Edit`, `Write`, or `NotebookEdit` tool is available to
+  you at all. Use `Bash` only for read commands (`git log`, `git diff`,
+  `git show`, `gh pr view`, `gh issue view`, test/build commands run to
+  *observe* current behavior) — never `git commit`, `git push`, `git merge`,
+  or anything that mutates the worktree or a ref.
+- **Bounded.** You were given one specific hypothesis/area and a base SHA.
+  Investigate that, not the whole repo. If you exhaust your reasonable
+  budget before reaching a conclusion, stop and report a partial finding
+  rather than continuing to explore.
+- **Evidence-backed.** Every claim needs a citation: `file:line`, literal
+  command output, or a PR/issue number and title (via `gh`). No unverified
+  assertions.
+- Read `CLAUDE.md` first if you have not already been given its contents —
+  it defines this repo's layer ownership and what counts as a contract
+  change.
+
+## Report format
+
+Report back in the exact ranked-candidate shape already used in
+`agent-state/candidates.md`, as one entry (the orchestrator will merge
+multiple scouts' entries into one ranked list):
+
+```
+**<short candidate title>**
+- Value: <why this is worth doing, one or two sentences>
+- Evidence: <file:line, command output, or PR/issue references>
+- Scope: <which files/areas would change>
+- Size/risk/verification: <small|medium|large> / <low|medium|high> / <low|medium|high>
+```
+
+If the finding is not yet actionable — it needs a fresher base, a
+reproducible profile, or some other precondition — say so explicitly instead
+of forcing a Size/risk/verification rating:
+
+```
+**<short candidate title>**
+- Value: <why this would matter if confirmed>
+- Evidence: <what you found so far>
+- Status: deferred pending <specific precondition>
+```
+
+If you found nothing worth queuing, say that plainly — an empty result is a
+valid and useful report; do not pad it with a low-value candidate just to
+have something to show.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -1,0 +1,67 @@
+---
+name: verifier
+description: Fresh-context, independent verification of a completed task packet — spawned only after an implementation agent claims a task is done, with no shared history with that agent. Reruns the packet's acceptance criteria and verification commands itself rather than trusting the implementer's claims, and reports PASS/FAIL with literal evidence. Use for the verify step of the repo-orchestrator loop, never to make the fix itself.
+tools: Read, Grep, Glob, Bash, Write
+---
+
+# Verifier
+
+You independently verify one task packet. You must be spawned with no
+context carried over from the implementation agent — treat every claim in
+the packet's status log as unverified until you reproduce it yourself.
+
+## Ground rules
+
+- **Never patch.** No `Edit` tool is available to you. If you find a
+  problem, report it — do not fix it yourself. The only thing you write is
+  your own evidence log, and only at the path you were given (normally
+  `agent-state/task-NNN/status.log` or similar, a sibling directory outside
+  the repo you're checking). Never write anywhere inside the repository
+  under test.
+- **No further delegation.** This repo's subagent policy caps delegation
+  depth at 1; you have no `Agent` tool.
+- **Reproduce, don't trust.** Re-read the task packet's acceptance criteria
+  and verification commands verbatim and run them exactly as specified —
+  do not paraphrase or substitute a command you think is equivalent.
+- Read `CLAUDE.md` first if it was not already provided — it defines this
+  repo's layer ownership, determinism/result-hash rules, and the
+  pull-request checklist your report should speak to.
+- Based on what actually changed, also run whichever existing project skill
+  applies: `build-and-test` for compiled/tested code, `acceptance-demo` for
+  anything touching hashing/serialization, `pr-checklist` for a general
+  final pass. Don't run checks the change couldn't possibly affect.
+
+## What you're given
+
+- The task packet (`agent-state/task-NNN/packet.md`): Task ID, Problem,
+  Evidence, Base SHA, Proposed branch, Expected files, Explicit non-goals,
+  Acceptance criteria, Verification commands, Expected runtime, Risks, Stop
+  conditions.
+- The implementation branch or worktree path to check out/inspect.
+
+## Report format
+
+One PASS/FAIL line per acceptance criterion, each with the literal command
+output (or a representative excerpt) as evidence, plus a top-line verdict:
+
+```
+## Verdict: PASS | FAIL
+
+- [PASS|FAIL] <acceptance criterion, verbatim from the packet>
+  Evidence: <literal command + output excerpt>
+- [PASS|FAIL] <next acceptance criterion>
+  Evidence: <...>
+
+## Non-goals check
+<confirm nothing outside "Expected files" changed, and nothing in
+"Explicit non-goals" was touched — cite `git diff --stat` against the base SHA>
+
+## Notes
+<anything the packet didn't anticipate: stop conditions triggered, risks
+that materialized, scope creep, etc.>
+```
+
+A single failed criterion makes the overall verdict FAIL. Do not round up.
+The orchestrator pushes and opens/updates a PR only on a PASS verdict from
+you — never on your own say-so as the implementer, and never on a partial
+pass.

--- a/.claude/skills/perf-branch-workflow/SKILL.md
+++ b/.claude/skills/perf-branch-workflow/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: perf-branch-workflow
+description: Investigates or fixes a performance regression/hotspot in an isolated git worktree, off origin/main, without touching the current checkout's uncommitted state — profiles before and after, and gates merge readiness on the CI "Performance budget" step (espressolab_cli bench) and the acceptance-demo determinism/hash check. Use when asked to investigate a slow path, optimize a hotspot, or verify a change doesn't regress simulation or dashboard performance.
+---
+
+# Performance Branch Workflow
+
+Performance work happens on its own branch, in its own worktree, profiled
+before and after, and is never considered mergeable on "it built" alone —
+it must be measured against this repo's actual performance budget.
+
+## Isolate the work
+
+Never make performance changes in a dirty current checkout. Create a
+separate worktree on its own branch, off `origin/main`:
+
+```bash
+git worktree add -b perf/<slug> <path-outside-the-repo> origin/main
+```
+
+If the current checkout has uncommitted changes, leave them exactly as they
+are — do not stash, revert, or fold them into the perf branch. This mirrors
+the same worktree-isolation discipline the `repo-orchestrator` skill uses
+for implementation tasks.
+
+## Baseline before changing anything
+
+Build and profile `origin/main` first, in its own worktree if you need a
+clean baseline separate from the perf branch (e.g.
+`git worktree add --detach <baseline-path> origin/main`). Record:
+
+- Wall-clock/allocation traces under `profiling/` (e.g. Instruments `.trace`
+  bundles, or equivalent for the platform you're on).
+- Structured before/after numbers under `results/` alongside whatever
+  artifact the change touches (a `cfd3d` case directory, a bundle-size
+  report, etc.) — follow the existing naming pattern already there
+  (`results/cfd3d-baseline/`, `results/cfd3d-heavy/`, etc.) rather than
+  inventing a new layout.
+
+Skipping the baseline capture is the single most common way this kind of
+work produces an unverifiable "it feels faster" claim — don't skip it.
+
+## Make the change, then re-measure
+
+Implement the change on the perf branch. Re-run the same profiling and
+benchmark steps used for the baseline, using identical inputs, and compare
+the numbers explicitly in whatever you report — not "it built and passed
+tests," but "before: X, after: Y."
+
+## Gate merge readiness
+
+Before calling a perf branch done, all of the following must hold:
+
+1. `./scripts/build.sh` and the relevant `[tag]` test(s) pass (see
+   `build-and-test`).
+2. The CI "Performance budget" step passes: `espressolab_cli bench --repeats
+   50` (`.github/workflows/ci.yml`), or run it locally with
+   `./build/apps/espressolab_cli/espressolab_cli bench --repeats 50` and
+   compare against the documented budget (currently a 60 s, 100 Hz shot at
+   ~0.468 ms median, well inside a 20 ms budget — see
+   `docs/current-state-and-gaps.md` and `docs/roadmap.md`). A perf change
+   that pushes this number *up* without an explicit reason is a regression,
+   not a win.
+3. `acceptance-demo`'s determinism check passes: a performance change must
+   never alter the result hash on the same build. If it does, it changed
+   physics or serialization, not just speed, and belongs through the
+   `data-contract-change` procedure instead — stop and re-scope.
+4. Web-side performance changes (bundle splitting, lazy loading, etc.) are
+   verified with `npm --prefix web run build` and the actual emitted
+   chunk/gzip sizes compared before/after, not assumed from the diff.
+
+## Clean up
+
+Once merged or abandoned, remove the worktree(s):
+
+```bash
+git worktree remove <path>
+```
+
+Leave `profiling/` traces and `results/` captures that back up the recorded
+before/after numbers; prune ones that were only exploratory scratch.
+
+## Related Skills
+
+- `build-and-test` — the build and `[tag]` test pass in step 1.
+- `acceptance-demo` — the determinism/hash check in step 3.
+- `repo-orchestrator` — if this perf work is one iteration of the broader
+  scout-to-PR loop, use that skill's task-packet and verification structure
+  around this procedure rather than running it standalone.

--- a/.claude/skills/repo-orchestrator/SKILL.md
+++ b/.claude/skills/repo-orchestrator/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: repo-orchestrator
+description: Runs the scout-to-PR iteration loop for this repo — refresh base, spawn bounded read-only scouts in parallel, consolidate a ranked candidate queue, get explicit approval, write a task packet, spawn one implementation agent in an isolated worktree, spawn a fresh verifier, push/open a PR only on PASS, then record the iteration. Use when asked to "keep iterating on this repo", "run a scouting round", "start/continue the orchestrator loop", or to pick up an in-progress agent-state/ session.
+---
+
+# Repo Orchestrator
+
+You act as a persistent orchestrator: manage repository state, delegate
+bounded tasks to subagents, evaluate evidence yourself rather than trusting
+subagent claims, and preserve continuity across iterations via files on
+disk. This is the loop the user has been running by hand; this skill is
+that loop, made repeatable.
+
+## State layout
+
+Two directories live as **siblings of the repo checkout** (e.g. next to
+`espressolab/`, not inside it) — never commit them, never put them under
+this repo's `.git`:
+
+- `agent-state/` — the session ledger, the candidate queue, and one
+  `task-NNN/` directory per selected task holding its packet and evidence
+  logs.
+- `agent-workspaces/` — one isolated git worktree per active implementation
+  task, e.g. `task-NNN-implementation`.
+
+Create both if they don't exist yet. If they already exist, read
+`agent-state/session.md` first — you may be resuming a session, not
+starting one.
+
+## Concurrency policy (hard rules)
+
+- **Delegation depth 1.** Subagents you spawn (`scout`, `verifier`, and the
+  implementation agent) never spawn subagents of their own — this is why
+  `scout` and `verifier` have no `Agent` tool.
+- **Max 3 concurrent agents** at any point in the loop.
+- **Exactly one active implementation agent at a time.** Never run two
+  implementation agents concurrently, even on different tasks.
+- **No parallel git operations on the same ref.** Two agents must never
+  push, merge, or rebase the same branch concurrently; isolated worktrees on
+  distinct branches avoid this by construction.
+- **Never touch pre-existing dirty state.** If the worktree you started in
+  already has uncommitted changes, preserve them exactly — do not revert,
+  discard, or fold your own work into them. Do all task work in a separate
+  worktree under `agent-workspaces/`.
+
+## Templates
+
+### Session ledger (`agent-state/session.md`)
+
+```markdown
+# Session Ledger
+
+## Current repository
+- Main SHA: <sha> (`origin/main`)
+- Existing PRs: <state of any open/recently merged PRs relevant to this session>
+- Original worktree status: <clean, or: dirty on `<branch>`; user changes present, not to be reverted>
+
+## Active task
+- Task ID: <TASK-NNN or "none">
+- State: <SCOUTING | QUEUED | IMPLEMENTING | VERIFYING | PR_OPEN | DONE>
+- Branch: <branch name, if any>
+- Assigned agent: <pending | in progress | done>
+- Last durable commit: <sha>
+- Next action: <one line, concrete>
+
+## Completed tasks
+- <one line per completed task/phase>
+
+## Candidate queue
+- <one line per queued candidate, with disposition>
+
+## Rejected candidates
+- <one line per rejected candidate, or "None">
+
+## Remaining budget
+- Estimated time: <estimate, or "not applicable">
+- Context condition: <what's still fresh vs. what needs re-checking>
+- Safe to start another iteration: <yes|no, and why>
+```
+
+### Candidate queue (`agent-state/candidates.md`)
+
+```markdown
+# Candidate Queue
+
+Base refreshed to `origin/main` `<sha>`.
+
+## Ranked candidates
+
+1. **<title>**
+   - Value: <why this is worth doing>
+   - Evidence: <file:line, command output, PR/issue references>
+   - Scope: <files/areas that would change>
+   - Size/risk/verification: <small|medium|large> / <low|medium|high> / <low|medium|high>
+
+2. **<title>**
+   - ...
+
+## Session disposition
+
+<what the user chose to do with this queue, and why — e.g. "selected
+candidate 1 as TASK-NNN", "no implementation this session, queue retained
+for a future approved iteration">
+```
+
+### Task packet (`agent-state/task-NNN/packet.md`)
+
+```markdown
+## Task packet
+- Task ID: TASK-NNN
+- Problem: <what's wrong or missing, precisely>
+- Evidence: <file:line references and/or measured numbers backing the problem statement>
+- Base SHA: <sha>
+- Proposed branch: <branch name>
+- Expected files: <the files this task should touch, and only these>
+- Explicit non-goals: <what must NOT change — be as specific as the task warrants>
+- Acceptance criteria: <a checkable list; include the exact commands/greps that must pass>
+- Verification commands: <literal commands the verifier will run>
+- Expected runtime: <rough estimate>
+- Risks: <what could go wrong or be misread>
+- Stop conditions: <when the implementation agent should stop and report back instead of proceeding>
+```
+
+## The loop
+
+1. **Refresh base.** `git fetch origin && git log origin/main -1` (or
+   equivalent) to get the current `origin/main` SHA. Check for any open PRs
+   relevant to the work (`gh pr list`, `gh pr view <n>`). Update the Session
+   ledger's "Current repository" section.
+2. **Scout in parallel.** For each hypothesis/area worth investigating,
+   spawn a `scout` agent (up to the 3-concurrent-agent cap) with a specific,
+   bounded brief and the current base SHA. Do not spawn a scout with a vague
+   "look around" brief — give it one hypothesis.
+3. **Consolidate.** Merge the scouts' reports into `agent-state/candidates.md`
+   using the Ranked candidates template above. Rank by value against
+   size/risk/verification, not just by value alone.
+4. **Get explicit approval.** Do not pick a candidate and start implementing
+   without the user confirming which one (or confirming "no implementation
+   this session"). Record the disposition in `candidates.md` either way.
+5. **Write the task packet.** Once a candidate is approved, write
+   `agent-state/task-NNN/packet.md` using the template above. Be as
+   concrete about non-goals and stop conditions as the existing task-001
+   packet is — vague packets produce implementation agents that either
+   under- or over-deliver.
+6. **Spawn one implementation agent.** Create
+   `agent-workspaces/task-NNN-implementation` as an isolated worktree on the
+   proposed branch, off the recorded base SHA. Give the implementation agent
+   the task packet and instruct it to read `CLAUDE.md` first. Update the
+   ledger's Active task state to `IMPLEMENTING`.
+7. **Spawn a fresh verifier.** Once the implementation agent reports done,
+   spawn a `verifier` agent with *no shared context* — give it only the task
+   packet and the branch/worktree to check, nothing else. Update state to
+   `VERIFYING`.
+8. **Act on the verdict.** On PASS: push the branch and open (or update) a
+   PR, referencing the task packet. On FAIL: do not push or open a PR;
+   record what failed and either send the implementation agent back with the
+   verifier's report or abandon the task — never patch it yourself as the
+   orchestrator without going through another verify pass.
+9. **Record and recompute.** Update the Session ledger: move the task to
+   Completed (or Rejected), update Remaining budget, and decide whether it's
+   safe to start another iteration this session.
+10. **Repeat or stop**, per the user's direction and the remaining budget.
+
+## Related Skills
+
+- `build-and-test`, `acceptance-demo`, `pr-checklist`, `data-contract-change`
+  — the implementation and verification steps should invoke whichever of
+  these applies to what actually changed, rather than reinventing checks.
+- `perf-branch-workflow` — if the selected candidate is a performance
+  change, use that skill's worktree/profiling/budget-gate procedure for
+  steps 6-8 instead of a generic implement/verify pass.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ web/dist/
 web/coverage/
 web/playwright-report/
 web/test-results/
+__pycache__/
+
+# Local scratch/tooling, not project source
+CoffeeSim/
+profiling/
+results/
+.opencode/
+session-*.md
+gitLog.txt

--- a/docs/superpowers/specs/2026-08-27-mem0-opencode-design.md
+++ b/docs/superpowers/specs/2026-08-27-mem0-opencode-design.md
@@ -1,0 +1,48 @@
+# Mem0 OpenCode Integration Design
+
+## Goal
+
+Give OpenCode persistent, cloud-backed memory for the EspressoLab project while
+keeping memories scoped to this repository and keeping credentials out of the
+worktree.
+
+## Scope
+
+This integration is for OpenCode only. It does not add Mem0 to the EspressoLab
+native solver, REST server, dashboard, build graph, or web dependencies.
+
+## Architecture
+
+Use the official `@mem0/opencode-plugin` as a project-level OpenCode plugin.
+Installing it without `--global` adds the plugin to the repository's
+`opencode.json`. The plugin provides native Mem0 tools, lifecycle hooks, and
+Mem0 skills through the `mem0ai` SDK; a separate MCP server is not needed.
+
+Remove the existing legacy global `@mem0/mcp-server` entry from
+`~/.config/opencode/opencode.json` to prevent duplicate Mem0 registrations.
+That user-level edit is local machine configuration and is not committed to the
+repository.
+
+## Credentials And Scope
+
+`MEM0_API_KEY` must be provided through the user's shell environment, preferably
+in `~/.zshrc` on this macOS development machine. The key must never be written
+to `opencode.json`, a project file, command history, or version control.
+
+The plugin's default `project` scope is retained. OpenCode must be launched
+from the repository so Mem0 derives the project identity from the EspressoLab
+git worktree. Global memory scope is not enabled by default.
+
+## Verification
+
+After installation and an OpenCode restart:
+
+1. Confirm the key is present without printing its value.
+2. Run `/mem0:health` and confirm cloud connectivity.
+3. Store a harmless project-specific test memory with `/mem0:remember`.
+4. Retrieve it with `/mem0:peek` and confirm it is associated with EspressoLab.
+5. Confirm only one Mem0 integration is active.
+
+No native or web test suite changes are required. If the cloud key is absent or
+invalid, installation remains safe but verification must stop at the credential
+error rather than placing a fallback secret in the repository.

--- a/docs/superpowers/specs/2026-09-01-real-shot-telemetry-design.md
+++ b/docs/superpowers/specs/2026-09-01-real-shot-telemetry-design.md
@@ -1,0 +1,147 @@
+# Next: fill the telemetry gap in the real-world reference shots
+
+## Context
+
+PR #56 landed the real-shot capture format, protocol, and a `pending_capture`
+fixture. All four CI jobs pass. The release is blocked on real-shot evidence,
+and you've confirmed you have no machine/refractometer — so the only route is
+public data.
+
+**During planning I found something that changes the recommendation.** The repo
+already contains four curated real shots I had not seen:
+`espresso_real_world_refs/` (tracked, committed in `58445b5`, served by the REST
+server via `--references` and rendered by `web/src/features/references/ReferenceShotsPanel.tsx`).
+
+They are from Jonathan Gagné's EG-1 vs Niche blooming-espresso experiment — the
+same Coffee Ad Astra author from the research brief — and the data is genuinely
+good:
+
+| Present | Absent |
+| --- | --- |
+| Decent DE1+, IMS shower head, Decent 18 g basket | `final_shot_time_s: null` |
+| Weber EG-1, SSP Ultra-Low-Fines burrs, setting 4.7 @ 1500 rpm | `timeseries: []` |
+| Dose 18.2 g, yield 74.8 g, drip 3.4 g, peak 5.0 bar | Basket diameter, puck depth |
+| TDS raw 6.38 % **and filtered 5.69 %**, uncertainty ±0.03 pp | PSD (setting 4.7 is a dial number) |
+| EY raw 26.2 % / filtered 23.4 % | Measured brew temperature, water recipe |
+| VST refractometer + VST syringe filter, room temperature | Roaster, roast date, storage |
+| Full puck prep: deep WDT, Cafelat paper top and bottom, Force Tamper | |
+
+I verified both EY figures reconcile against `tds × yield ÷ dose` (23.38 and
+26.22), so the record is internally consistent — a real quality signal.
+
+The manifest states the hole precisely:
+
+> "No telemetry was fabricated. `final_shot_time_s` is null and `timeseries` is
+> empty until the original DE1 `.shot` files are parsed."
+
+So the highest-value next step is not importing an arbitrary Visualizer shot —
+it is **closing the gap the repo has already scoped for itself**, using the
+Visualizer importer as the mechanism. `timeseries_fields` in those records is
+already `[time_s, pressure_bar, flow_ml_s, beverage_mass_g, temperature_c]`,
+which is the telemetry column set from PR #56 in all but one name.
+
+## The gate this plan turns on
+
+The telemetry for those four specific 2021-03-02 shots may or may not be
+publicly retrievable. I probed this and it is genuinely uncertain:
+
+- `GET https://visualizer.coffee/api/shots/<uuid>` works anonymously and returns
+  full telemetry (I pulled a 351-sample shot successfully).
+- But `?user_id=`, `?q=`, `/shots/search`, and `/users/<id>/shots` are ignored or
+  404 anonymously — so **locating Gagné's specific shots by author is not solved.**
+
+**Step 1 is therefore a timeboxed acquisition spike, not construction.**
+
+### Step 1 — Acquisition spike (do this first, ~30 min, read-only)
+
+Try, in order, to obtain telemetry for `20210302T094131.shot` and its three siblings:
+
+1. The `experiment_log_url` Google Sheet already recorded in each file's `source`.
+2. The `article_url` on coffeeadastra.com for linked raw shot files.
+3. Visualizer, for shots matching the coffee (`Asotbilbao`), grinder (EG-1 SSP
+   ULF), and date (2021-03-02).
+
+Then **stop and report** which of the two paths below is live. Do not build
+before this resolves.
+
+### Step 2A — If the four shots' telemetry is obtainable (preferred)
+
+- Add a DE1 `.shot` / Visualizer-JSON → telemetry parser as a stdlib-only Python
+  tool (`tools/import_shot_telemetry.py`). Python, not C++: the repo must build
+  offline from a clean clone, and an HTTPS client would mean a new vendored
+  dependency. Precedent is the existing stdlib-only tooling in `tests/schemas/`,
+  `tests/pty/`, `tests/cli/`.
+- Populate `timeseries` and `final_shot_time_s` in the four
+  `espresso_real_world_refs/*.json` records, updating each `data_quality` block
+  to say the telemetry is now populated and from where.
+- Extend `tests/unit/test_reference_io.cpp` for the now-non-empty series.
+
+### Step 2B — If it is not obtainable (fallback)
+
+- Point the same importer at a fully public Visualizer shot and emit an
+  `external_public` capture record + telemetry CSV in the PR #56 format.
+- Record in `espresso_real_world_refs/*.json` that the telemetry could not be
+  retrieved, and what would be needed — so the gap is documented rather than
+  left silently open.
+
+## Schema refinements this real data forces
+
+Applying the PR #56 format to actual records surfaced three gaps. These are
+small, and each is a correction the real data proved necessary:
+
+1. **`tds_method.readings_percent` must not be mandatory for `external_public`.**
+   The current rule in `tests/schemas/real_shot_capture_check.py` ("tds_percent
+   recorded but readings empty") is right for a first-party `measured` shot, but
+   a public source publishes an aggregate. Scope the rule to `status == "measured"`.
+2. **Raw and filtered TDS need separate fields.** Gagné reports both plus an
+   uncertainty; the schema currently has a single `tds_percent` and a boolean
+   `filtered`. Add `tds_raw_percent`, `tds_filtered_percent`,
+   `tds_uncertainty_percent_points`, and make `tds_percent` name which one is
+   authoritative.
+3. **`grinder.dial_setting` must be stringified on import.** These files store it
+   as the number `4.7`; the capture format requires a string, deliberately, so it
+   can never be read as microns. The importer converts verbatim — `"4.7"`, never
+   a unit conversion.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `tools/import_shot_telemetry.py` | New. Stdlib only. Fetch/parse → telemetry rows |
+| `espresso_real_world_refs/*.json` (4) | Populate `timeseries`, `final_shot_time_s`, update `data_quality` |
+| `espresso_real_world_refs/manifest.json` | Update the "no telemetry" note once it is no longer true |
+| `schemas/real-shot-capture.schema.json` | The three TDS/dial refinements above |
+| `tests/schemas/real_shot_capture_check.py` | Scope the readings rule to `measured`; cover raw/filtered TDS |
+| `tests/unit/test_reference_io.cpp` | Non-empty `timeseries` cases |
+| `docs/real-shot-validation.md` | Record the outcome and correct the source table |
+
+## Reuse — do not rebuild
+
+- `calibration::compare_shot_result()` (`engine/calibration/loss.cpp:111`,
+  declared `include/espressolab/calibration.hpp:174`) is already the shared
+  authority for scoring a result against a measured shot, used by the server's
+  `/api/v1/measured-shots/<id>/compare` route. Any comparison work reuses it.
+- `interpolate_beverage_mass_g()` already handles off-grid sample times.
+- `engine/reference_io/reference_io.cpp` already loads these records.
+
+## Verification
+
+- `python3 tests/schemas/real_shot_capture_check.py` — passes.
+- `./build/tests/espressolab_tests "[references]"` and `"[calibration]"` — pass.
+- `./scripts/demo.sh` — determinism/hash unchanged. Nothing here touches the
+  solver, but the reference records are server-served, so confirm it.
+- `npm --prefix web run test:coverage` — the ReferenceShotsPanel renders the
+  now-populated records.
+- Re-run the importer on the same input and diff: byte-identical output.
+
+## Explicitly out of scope
+
+Per your standing brief, and unchanged by this plan: no performance work, no
+gamification, no new CFD3D features, no dashboard work beyond what a populated
+reference record renders. Your ~2000 lines of uncommitted working-tree changes
+stay untouched, as you asked.
+
+**No calibration, and no validation claim.** Even with telemetry, these shots
+lack basket diameter, puck depth, PSD, and a measured brew temperature, so they
+cannot be simulated without inventing inputs. The honest outcome is real curves
+for shape comparison and documented provenance — not a calibrated model.

--- a/docs/superpowers/specs/2026-09-01-real-shot-validation-phase2-design.md
+++ b/docs/superpowers/specs/2026-09-01-real-shot-validation-phase2-design.md
@@ -1,0 +1,70 @@
+# Real-shot validation, phase 2: what's next
+
+## This session, briefly
+
+Implemented `docs/superpowers/specs/2026-09-01-real-shot-telemetry-design.md`
+in full:
+
+- **Acquisition spike resolved immediately on path 2, not Visualizer.** The
+  Coffee Ad Astra article behind the four `espresso_real_world_refs/*.json`
+  records links a zipped Dropbox archive of the author's 11 raw DE1 `.shot`
+  exports, and all four target files were in it. Verified by matching
+  `drink_weight`/`scale_weight` and `profile_notes` against the already-
+  committed shot-level metadata.
+- **New `tools/import_shot_telemetry.py`** (stdlib-only) parses the DE1
+  `.shot` format and populated `timeseries` + `observed.final_shot_time_s`
+  for all four Gagné EG-1/Niche shots. Raw `.shot` files are not vendored
+  (no explicit license on the archive) — only derived numeric samples are.
+- **`telemetry_available` was hardcoded `false` everywhere** (C++ and TS) —
+  now computed per-reference and catalogue-wide from actual content.
+- **Schema refinements the real data forced**: `tds_raw_percent` /
+  `tds_filtered_percent` / `tds_uncertainty_percent_points` added to the
+  capture schema (`tds_method.filtered` names which is authoritative,
+  checked for consistency); the "every TDS reading must be kept" rule
+  scoped to `status == "measured"` (an `external_public` record only has a
+  published aggregate to transcribe).
+- Verified: full Catch2 suite (229 cases / 88,154 assertions),
+  `real_shot_capture_check.py`, `scripts/demo.sh` (hash unchanged), web
+  typecheck/`test:coverage`/build. Importer re-run is byte-identical.
+- Committed as `68a2747` on `feat/real-shot-capture-template`, pushed to
+  origin.
+
+**No calibration, no validation claim** — unchanged. These four shots still
+lack basket diameter, puck depth, PSD, and a measured brew temperature.
+
+## Load-bearing fact for next session
+
+`feat/real-shot-capture-template`'s first commit (`1089957`, the PR #56
+capture-template work) is **already merged into `main`** (merge commit
+`899d3a7`). This session's commit (`68a2747`) sits on top of it and is
+**not yet in `main`** — it needs its own new PR, not a reopen of #56. `main`
+is otherwise caught up to this branch, so it's a clean one-commit PR.
+
+## Immediate next step
+
+Open a PR from `feat/real-shot-capture-template` (HEAD `68a2747`) into
+`main` for this session's telemetry work.
+
+## Deferred, not done
+
+- **Step 2B** (Visualizer-JSON → `external_public` capture record) was
+  never exercised — 2A resolved first. `tools/import_shot_telemetry.py`'s
+  docstring says so explicitly. Only add a Visualizer-JSON parser branch
+  against an actual Visualizer export, not speculatively.
+- `assets/real_shots/` still holds only the `pending_capture` fixture — no
+  `measured` or `external_public` capture record exists yet.
+- The ~2000 lines of unrelated pre-existing uncommitted work in this
+  worktree (README.md, `engine/cfd3d/cfd3d_solver.cpp`, the web dashboard
+  revamp files, etc.) were deliberately left untouched all session. Do not
+  fold them into the PR above; they're a separate thread.
+
+## Candidate follow-on work (pick one; don't assume which)
+
+1. **First-party capture**: brew a real shot per the protocol in
+   `docs/real-shot-validation.md`, promote it to
+   `assets/real_shots/*.capture.json` with `status: "measured"`.
+2. **Reconcile specs**: `docs/superpowers/specs/2026-08-25-real-shot-validation-design.md`
+   may overlap or contradict the telemetry work now implemented — check on
+   first touch.
+3. **Visualizer parser**, only if a future shot's telemetry is unreachable
+   any other way (build it against a real sample, per the note above).

--- a/engine/cfd3d/cfd3d_solver.cpp
+++ b/engine/cfd3d/cfd3d_solver.cpp
@@ -481,21 +481,30 @@ Cfd3dResult Cfd3dSolver::run(const Recipe& recipe, const ModelCoefficients& coef
 
     const auto make_sample = [&](double sample_time, double flow_m3_s) {
         double retained_total = 0.0;
-        double capacity_total = 0.0;
+        double pore_capacity_total = 0.0;
+        double thermal_capacity_total = 0.0;
         double weighted_temperature = 0.0;
         for (std::size_t node = 0; node < node_count; ++node) {
             retained_total += state.retained_water_kg[node];
-            const double capacity = node_capacity(geometry, node % active_count, bed.porosity,
-                                                  current_water[node].density_kg_m3);
-            capacity_total += capacity;
-            weighted_temperature += capacity * state.temperature_k[node];
+            const double area = geometry.aggregate_area_xy_m2[node % active_count];
+            const double dose_share = recipe.dose_kg * area / basket_area_m2 /
+                                      static_cast<double>(mesh.nz);
+            const double pore_capacity = node_capacity(geometry, node % active_count, bed.porosity,
+                                                       current_water[node].density_kg_m3);
+            const double thermal_capacity =
+                dose_share * coeff.coffee_heat_capacity_j_kg_k +
+                std::max(state.retained_water_kg[node], 0.0) *
+                    current_water[node].heat_capacity_j_kg_k;
+            pore_capacity_total += pore_capacity;
+            thermal_capacity_total += thermal_capacity;
+            weighted_temperature += thermal_capacity * state.temperature_k[node];
         }
         ShotSample sample;
         sample.time_s = sample_time;
         sample.pressure_pa = recipe.pressure_pa.sample(sample_time);
         sample.inlet_temperature_k = recipe.inlet_temperature_k.sample(sample_time);
-        sample.puck_temperature_k = capacity_total > kMassEpsilon
-                                       ? weighted_temperature / capacity_total
+        sample.puck_temperature_k = thermal_capacity_total > kMassEpsilon
+                                       ? weighted_temperature / thermal_capacity_total
                                        : coeff.initial_puck_temperature_k;
         sample.flow_m3_s = flow_m3_s;
         sample.beverage_mass_kg = beverage_mass_kg;
@@ -505,7 +514,9 @@ Cfd3dResult Cfd3dSolver::run(const Recipe& recipe, const ModelCoefficients& coef
         sample.extraction_yield_fraction = recipe.dose_kg > kMassEpsilon
                                                 ? solids_in_cup_kg / recipe.dose_kg
                                                 : 0.0;
-        sample.saturation = capacity_total > kMassEpsilon ? retained_total / capacity_total : 0.0;
+        sample.saturation = pore_capacity_total > kMassEpsilon
+                                ? retained_total / pore_capacity_total
+                                : 0.0;
         sample.permeability_m2 = absolute_permeability_m2;
         result.samples.push_back(sample);
     };
@@ -718,7 +729,8 @@ Cfd3dResult Cfd3dSolver::run(const Recipe& recipe, const ModelCoefficients& coef
                 recipe.dose_kg * geometry.aggregate_area_xy_m2[node % active_count] / basket_area_m2 /
                 static_cast<double>(mesh.nz);
             const double loss_power = coeff.ambient_heat_loss_w_k *
-                                      (geometry.aggregate_area_xy_m2[node % active_count] / basket_area_m2) *
+                                      (geometry.aggregate_area_xy_m2[node % active_count] / basket_area_m2) /
+                                      static_cast<double>(mesh.nz) *
                                       (old_temperature - coeff.ambient_temperature_k);
             const double old_energy = dose_share * coeff.coffee_heat_capacity_j_kg_k * old_temperature +
                                       state.retained_water_kg[node] * cp * old_temperature;
@@ -784,7 +796,8 @@ Cfd3dResult Cfd3dSolver::run(const Recipe& recipe, const ModelCoefficients& coef
                 std::max(result.diagnostics.max_total_velocity_divergence_1_s,
                          std::abs(total_flux_per_node[node]) /
                              std::max(area * geometry.public_geometry.dz_m, kMassEpsilon));
-            const double loss_power = coeff.ambient_heat_loss_w_k * (area / basket_area_m2) *
+            const double loss_power = coeff.ambient_heat_loss_w_k * (area / basket_area_m2) /
+                                      static_cast<double>(mesh.nz) *
                                       (state.temperature_k[node] - coeff.ambient_temperature_k);
             ambient_energy_loss_j += loss_power * dt;
         }

--- a/tests/integration/test_cfd3d.cpp
+++ b/tests/integration/test_cfd3d.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -12,6 +13,8 @@
 #include "espressolab/artifact_io.hpp"
 #include "espressolab/cfd3d.hpp"
 #include "espressolab/cfd3d_artifact_io.hpp"
+#include "espressolab/puck.hpp"
+#include "espressolab/units.hpp"
 
 using namespace espressolab;
 
@@ -66,6 +69,123 @@ TEST_CASE("cfd3d produces bounded deterministic fields", "[cfd3d][verification]"
         REQUIRE(value >= 0.0);
         REQUIRE(value <= 1.0 + 1.0e-9);
     }
+}
+
+TEST_CASE("cfd3d ambient cooling is independent of axial refinement", "[cfd3d][heat][verification]") {
+    Recipe recipe = testing::baseline_recipe();
+    recipe.pressure_pa = PiecewiseLinearProfile::constant(0.0);
+    recipe.target_beverage_mass_kg.reset();
+    recipe.maximum_time_s = 10.0;
+
+    ModelCoefficients coefficients = testing::baseline_coefficients();
+    coefficients.initial_puck_temperature_k = units::celsius_to_kelvin(90.0);
+    coefficients.ambient_heat_loss_w_k = 2.0;
+
+    auto run = [&](int axial_cells) {
+        Cfd3dConfig config;
+        config.mesh = {6, 6, axial_cells};
+        config.dt_s = 0.01;
+        config.sample_interval_s = 0.5;
+        config.snapshot_interval_s = 0.0;
+        return Cfd3dSolver().run(recipe, coefficients, config);
+    };
+
+    const Cfd3dResult coarse = run(2);
+    const Cfd3dResult refined = run(16);
+    REQUIRE(coarse.samples.back().puck_temperature_k ==
+            Catch::Approx(refined.samples.back().puck_temperature_k).margin(1.0e-9));
+}
+
+TEST_CASE("cfd3d hot inlet and puck preserve temperature without ambient loss",
+          "[cfd3d][heat][verification]") {
+    Recipe recipe = testing::baseline_recipe();
+    recipe.target_beverage_mass_kg.reset();
+    recipe.maximum_time_s = 10.0;
+
+    ModelCoefficients coefficients = testing::baseline_coefficients();
+    const double hot_temperature = units::celsius_to_kelvin(93.0);
+    coefficients.initial_puck_temperature_k = hot_temperature;
+    coefficients.ambient_heat_loss_w_k = 0.0;
+
+    Cfd3dConfig config = small_config();
+    config.snapshot_interval_s = 0.0;
+    const Cfd3dResult result = Cfd3dSolver().run(recipe, coefficients, config);
+
+    for (const ShotSample& sample : result.samples) {
+        REQUIRE(sample.puck_temperature_k == Catch::Approx(hot_temperature).margin(1.0e-9));
+    }
+}
+
+TEST_CASE("cfd3d reports temperature using actual thermal capacity",
+          "[cfd3d][heat][verification]") {
+    Recipe recipe = short_recipe();
+    recipe.target_beverage_mass_kg.reset();
+    recipe.maximum_time_s = 10.0;
+    ModelCoefficients coefficients = testing::baseline_coefficients();
+    coefficients.ambient_heat_loss_w_k = 0.0;
+
+    Cfd3dConfig config = small_config();
+    config.snapshot_interval_s = 0.0;
+    config.material = Cfd3dMaterialField(config.mesh.nx, config.mesh.ny, config.mesh.nz, 1.0);
+    for (int z = 0; z < config.mesh.nz; ++z) {
+        for (int y = 0; y < config.mesh.ny; ++y) {
+            config.material.at(config.mesh.nx - 1, y, z) = 8.0;
+        }
+    }
+
+    const Cfd3dResult result = Cfd3dSolver().run(recipe, coefficients, config);
+    const Cfd3dMesh& mesh = result.geometry.mesh;
+    const std::size_t xy_count = static_cast<std::size_t>(mesh.nx) *
+                                 static_cast<std::size_t>(mesh.ny);
+    double minimum_temperature = std::numeric_limits<double>::infinity();
+    double maximum_temperature = -std::numeric_limits<double>::infinity();
+    for (std::size_t xy = 0; xy < xy_count; ++xy) {
+        if (result.geometry.cell_area_xy_m2[xy] <= 0.0) continue;
+        for (int z = 0; z < mesh.nz; ++z) {
+            const double temperature = result.temperature_k.values()[xy + xy_count *
+                                                                       static_cast<std::size_t>(z)];
+            minimum_temperature = std::min(minimum_temperature, temperature);
+            maximum_temperature = std::max(maximum_temperature, temperature);
+        }
+    }
+    REQUIRE(maximum_temperature - minimum_temperature > 1.0e-6);
+
+    std::vector<double> aggregate_area(xy_count, 0.0);
+    for (std::size_t xy = 0; xy < xy_count; ++xy) {
+        const int root = result.geometry.agglomerate_parent[xy];
+        if (root >= 0) aggregate_area[static_cast<std::size_t>(root)] +=
+            result.geometry.cell_area_xy_m2[xy];
+    }
+
+    TabulatedWaterProperties water;
+    const double porosity =
+        compress_puck(recipe, coefficients,
+                      recipe.pressure_pa.max_value() - coefficients.outlet_pressure_pa)
+            .porosity;
+    double expected_weighted_temperature = 0.0;
+    double thermal_capacity_total = 0.0;
+    for (std::size_t xy = 0; xy < xy_count; ++xy) {
+        if (result.geometry.agglomerate_parent[xy] != static_cast<int>(xy)) continue;
+        const double area = aggregate_area[xy];
+        for (int z = 0; z < mesh.nz; ++z) {
+            const std::size_t index = xy + xy_count * static_cast<std::size_t>(z);
+            const double temperature = result.temperature_k.values()[index];
+            const double capacity = area * result.geometry.dz_m * porosity *
+                                    water.density_kg_m3(temperature);
+            const double retained = result.saturation.values()[index] * capacity;
+            const double dose_share = recipe.dose_kg * area / recipe.basket_area_m2() /
+                                      static_cast<double>(mesh.nz);
+            const double thermal_capacity =
+                dose_share * coefficients.coffee_heat_capacity_j_kg_k +
+                retained * water.heat_capacity_j_kg_k(temperature);
+            thermal_capacity_total += thermal_capacity;
+            expected_weighted_temperature += thermal_capacity * temperature;
+        }
+    }
+
+    REQUIRE(thermal_capacity_total > 0.0);
+    REQUIRE(result.samples.back().puck_temperature_k ==
+            Catch::Approx(expected_weighted_temperature / thermal_capacity_total).margin(1.0e-9));
 }
 
 // Regression: cfd3d_artifact_io::result_hash() used to hash dump_case_json()

--- a/tests/schemas/schema_contract_check.py
+++ b/tests/schemas/schema_contract_check.py
@@ -49,7 +49,8 @@ def load_schema(path: Path):
 def schema_accepts(schema, instance, registry=None) -> tuple[bool, str]:
     try:
         validator = jsonschema.Draft202012Validator(
-            schema, registry=registry if registry is not None else referencing.Registry()
+            schema,
+            registry=registry if registry is not None else referencing.Registry(),
         )
         validator.validate(instance)
         return True, ""

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -99,7 +99,12 @@ test("pinning a run keeps its label correct after the draft is edited (Audit P7 
   // column must still show the submitted dose (18g), not the new draft.
   await page.getByLabel("Dose (g)").fill("14");
 
-  await page.getByRole("tab", { name: "References" }).click();
+  // Audit #06: References merged into the Calibration tab's shared
+  // ground-truth list; select the first published reference row to see its
+  // metadata table (the real catalogue's reference ids vary by asset file,
+  // unlike the vitest fixture's fixed "real_gagne_shot_01").
+  await page.getByRole("tab", { name: "Calibration" }).click();
+  await page.getByRole("button", { name: /published/i }).first().click();
   const referenceTable = page.getByRole("table");
   const doseRow = referenceTable.getByRole("row").filter({ hasText: "Dose" });
   await expect(doseRow.locator(".current-model")).toHaveText("18.0 g");

--- a/web/e2e/measured-shot.spec.ts
+++ b/web/e2e/measured-shot.spec.ts
@@ -7,8 +7,11 @@ import { expect, test } from "@playwright/test";
 
 test("comparing a measured shot issues exactly one compare request", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("tab", { name: "Measured data" }).click();
-  await expect(page.getByLabel(/measured shot/i)).toBeVisible();
+  // Audit #06: the "Measured data" tab merged into "Calibration", and the
+  // measured-shot picker's own <select> is folded into the shared
+  // ground-truth list, so the compare button is what's waited on here.
+  await page.getByRole("tab", { name: "Calibration" }).click();
+  await expect(page.getByRole("button", { name: /compare with default-v1/i })).toBeVisible();
 
   let compareRequests = 0;
   page.on("request", (request) => {

--- a/web/e2e/profile-editor.spec.ts
+++ b/web/e2e/profile-editor.spec.ts
@@ -47,12 +47,12 @@ test("drags a pressure-profile point with the pointer", async ({ page }) => {
   expect(after).not.toBe(before);
 });
 
-test("edits a profile point through the numeric disclosure and it stays in sync with the graphical control", async ({ page }) => {
+test("edits a profile point through the numeric table and it stays in sync with the graphical control", async ({ page }) => {
   await page.goto("/");
   await openRecipeEditor(page);
-  // The pressure profile's disclosure is the first "Edit numeric points"
-  // button on the page (ControlRail renders the pressure section first).
-  await page.getByRole("button", { name: /edit numeric points/i }).first().click();
+  // Audit #08: the numeric points are always visible now, with no disclosure
+  // toggle to open first. "Point 1 value in bar" is the pressure profile's
+  // field (ControlRail renders the pressure section first).
   const valueInput = page.getByLabel("Point 1 value in bar");
   await valueInput.fill("5");
   await valueInput.blur();

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Lora:ital,wght@0,400;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
     <title>EspressoLab</title>
   </head>
   <body>

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -51,10 +51,14 @@ describe("App: independent data loading", () => {
   });
 
   it("renders once health, recipes and references have each resolved, even though none of them share a request", async () => {
+    const user = userEvent.setup();
     render(<App />);
     await screen.findByText(/0\.1\.0-test/);
     await screen.findByRole("option", { name: /baseline/i });
-    await screen.findByText(/real-world references/i);
+    await user.click(screen.getByRole("tab", { name: "Calibration" }));
+    // The reference catalogue landing shows up as a row in the shared
+    // ground-truth list (audit #06), not its own tab.
+    await screen.findByText(/published · metadata only/i);
   });
 
   it("shows a connection message and still loads recipes when health fails", async () => {
@@ -66,8 +70,10 @@ describe("App: independent data loading", () => {
 
   it("surfaces a reference-catalogue error independently of a working recipe load", async () => {
     server.use(http.get("/api/v1/reference-shots", () => HttpResponse.error()));
+    const user = userEvent.setup();
     render(<App />);
     await screen.findByRole("option", { name: /baseline/i });
+    await user.click(screen.getByRole("tab", { name: "Calibration" }));
     await screen.findByText(/reference catalogue unavailable/i);
   });
 
@@ -119,7 +125,7 @@ describe("App: workflow navigation", () => {
     await user.type(dose, "2");
     expect(screen.getByRole("alert")).toHaveTextContent(/must be between 14 and 22/i);
 
-    await user.click(screen.getByRole("tab", { name: "Measured data" }));
+    await user.click(screen.getByRole("tab", { name: "Calibration" }));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
@@ -130,7 +136,7 @@ describe("App: workflow navigation", () => {
     await screen.findByRole("alert");
     expect(screen.getByRole("alert")).toHaveTextContent(/recipe catalogue unavailable/i);
 
-    await user.click(screen.getByRole("tab", { name: "References" }));
+    await user.click(screen.getByRole("tab", { name: "Calibration" }));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });
@@ -198,7 +204,10 @@ describe("App: running a simulation", () => {
     // The reference panel's "current model" column must reflect the recipe
     // that was *submitted* (18 g), never the draft as it stands once the
     // response lands (20 g) -- App.tsx's activeRecipe contract.
-    await user.click(screen.getByRole("tab", { name: "References" }));
+    await user.click(screen.getByRole("tab", { name: "Calibration" }));
+    // Audit #06: a reference now lives as a row in the shared ground-truth
+    // list; select it to see its metadata table.
+    await user.click(await screen.findByRole("button", { name: /shot 01/i }));
     const referenceTable = screen.getByRole("table");
     const doseRow = within(referenceTable).getAllByRole("row").find((row) => /dose/i.test(row.textContent ?? ""));
     expect(doseRow).toBeDefined();
@@ -312,7 +321,10 @@ describe("App: reference panel association (regression, Audit P7 issue #22 patte
     await user.clear(doseField);
     await user.type(doseField, "14");
 
-    await user.click(screen.getByRole("tab", { name: "References" }));
+    await user.click(screen.getByRole("tab", { name: "Calibration" }));
+    // Audit #06: a reference now lives as a row in the shared ground-truth
+    // list; select it to see its metadata table.
+    await user.click(await screen.findByRole("button", { name: /shot 01/i }));
     const referenceTable = screen.getByRole("table");
     const doseRow = within(referenceTable).getAllByRole("row").find((row) => /dose/i.test(row.textContent ?? ""));
     // Must still read 18.0 g (the submitted recipe), not 14 (the live draft).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,6 @@ import { ApiFailure, api } from "./api/client";
 import type { Recipe, ShotResult } from "./api/types";
 import { type WorkflowId, WorkflowTabs } from "./app/WorkflowTabs";
 import { hasRecipe, useBootstrap } from "./app/useBootstrap";
-import { ReferenceShotsPanel } from "./features/references/ReferenceShotsPanel";
 import { ShotWorkspace } from "./features/shot/ShotWorkspace";
 import {
   fallbackRecipe,
@@ -12,17 +11,18 @@ import {
   type ShotWorkspace as ShotWorkspaceState,
 } from "./state/workspace";
 
-// Both panels below are recharts consumers (see the note in ChartStack's
-// lazy import); they're the only two chart panels that render regardless of
+// Both panels below are recharts consumers (Calibration renders
+// MeasuredShotComparison; SweepPanel renders its own heat map and profile
+// charts); they're the only two chart panels that render regardless of
 // which tab is active (hidden by CSS, not unmounted -- App: workflow
 // navigation's "preserves workflow-local state" contract needs them to stay
 // mounted once visited). Loading them eagerly would pull recharts back into
 // the initial bundle no matter how the Shot tab defers ChartStack, so each
 // is its own dynamic import and neither renders until its tab has been
 // opened at least once.
-const MeasuredShotComparison = lazy(() =>
-  import("./features/calibration/MeasuredShotComparison").then((mod) => ({
-    default: mod.MeasuredShotComparison,
+const Calibration = lazy(() =>
+  import("./features/calibration/Calibration").then((mod) => ({
+    default: mod.Calibration,
   })),
 );
 const SweepPanel = lazy(() =>
@@ -35,7 +35,7 @@ export function App() {
   const [sweepError, setSweepError] = useState<string>();
   const [pinned, setPinned] = useState<ShotResult[]>([]);
   const [activeWorkflow, setActiveWorkflow] = useState<WorkflowId>("shot");
-  // Tracks every tab that has ever been opened, so the Measured data and
+  // Tracks every tab that has ever been opened, so the Calibration and
   // Sweeps panels (each `hidden`, not unmounted, once visited -- see the
   // dynamic-import note above) mount their lazy chunk once and then stay
   // mounted, instead of never rendering or re-fetching on every tab switch.
@@ -202,42 +202,30 @@ export function App() {
         </section>
 
         <section
-          id="workflow-panel-measured"
+          id="workflow-panel-calibration"
           className="workflow-panel"
           role="tabpanel"
-          aria-labelledby="workflow-tab-measured"
-          hidden={activeWorkflow !== "measured"}
+          aria-labelledby="workflow-tab-calibration"
+          hidden={activeWorkflow !== "calibration"}
         >
           <header className="workflow-heading">
-            <p className="eyebrow">Fixed-coefficient evaluation</p>
-            <h2>Measured data</h2>
-            <p>Compare one stored shot with one native simulation. This workflow never fits coefficients.</p>
+            <p className="eyebrow">Measured against simulated</p>
+            <h2>Calibration</h2>
+            <p>
+              Measured shots and published references are both ground truth, so they share one list.
+              This workflow never fits coefficients.
+            </p>
           </header>
-          {visitedWorkflows.has("measured") && (
-            <Suspense fallback={<p className="note" aria-live="polite">Loading measured-data workflow...</p>}>
-              <MeasuredShotComparison />
+          {visitedWorkflows.has("calibration") && (
+            <Suspense fallback={<p className="note" aria-live="polite">Loading calibration workflow...</p>}>
+              <Calibration
+                referenceCatalogue={referenceCatalogue}
+                referenceError={referenceError}
+                active={active}
+                recipe={workspace.activeRecipe}
+              />
             </Suspense>
           )}
-        </section>
-
-        <section
-          id="workflow-panel-references"
-          className="workflow-panel"
-          role="tabpanel"
-          aria-labelledby="workflow-tab-references"
-          hidden={activeWorkflow !== "references"}
-        >
-          <header className="workflow-heading">
-            <p className="eyebrow">Context, not validation</p>
-            <h2>Reference catalogue</h2>
-            <p>Inspect published metadata and synthetic fixtures alongside the active model result.</p>
-          </header>
-          <ReferenceShotsPanel
-            catalogue={referenceCatalogue}
-            error={referenceError}
-            active={active}
-            recipe={workspace.activeRecipe}
-          />
         </section>
 
         <section

--- a/web/src/a11y.test.tsx
+++ b/web/src/a11y.test.tsx
@@ -41,9 +41,11 @@ describe("Accessibility: stable application states", () => {
     const user = userEvent.setup();
     const { container } = render(<App />);
     await screen.findByRole("option", { name: /baseline/i });
-    await user.click(screen.getByRole("tab", { name: /measured data/i }));
-    await screen.findByLabelText(/measured shot/i);
-    await user.click(screen.getByRole("button", { name: /compare with default-v1/i }));
+    await user.click(screen.getByRole("tab", { name: /calibration/i }));
+    // Audit #06: the measured-shot picker is folded into the shared
+    // ground-truth list now, so the compare button is reachable directly
+    // rather than through the comparison's own (now hidden) <select>.
+    await user.click(await screen.findByRole("button", { name: /compare with default-v1/i }));
     await screen.findByText(/mass rmse/i);
     await expectNoSeriousViolations(container);
   }, 15000);
@@ -69,7 +71,7 @@ describe("Accessibility: stable application states", () => {
     await expectNoSeriousViolations(container);
   }, 15000);
 
-  it("an open diagnostics drawer and an open profile editor have no serious/critical violations", async () => {
+  it("an open diagnostics drawer and the always-visible profile editor have no serious/critical violations", async () => {
     server.use(http.post("/api/v1/shots", () => HttpResponse.json(makeShotResult())));
     const user = userEvent.setup();
     const { container } = render(<App />);
@@ -81,7 +83,8 @@ describe("Accessibility: stable application states", () => {
     // the accessibility-tree approximation RTL's getByRole uses, so it is
     // targeted by its own text instead.
     await user.click(screen.getByText(/^Diagnostics —/));
-    await user.click(screen.getAllByRole("button", { name: /edit numeric points/i })[0]);
+    // Audit #08: the profile editor's numeric points are on screen by
+    // default now, with no disclosure toggle to open first.
     await expectNoSeriousViolations(container);
   }, 15000);
 });

--- a/web/src/app/WorkflowTabs.test.tsx
+++ b/web/src/app/WorkflowTabs.test.tsx
@@ -23,7 +23,7 @@ describe("WorkflowTabs", () => {
     shot.focus();
 
     await user.keyboard("{ArrowRight}");
-    expect(onChange).toHaveBeenLastCalledWith("measured");
+    expect(onChange).toHaveBeenLastCalledWith("calibration");
     await user.keyboard("{End}");
     expect(onChange).toHaveBeenLastCalledWith("sweeps");
     await user.keyboard("{Home}");

--- a/web/src/app/WorkflowTabs.tsx
+++ b/web/src/app/WorkflowTabs.tsx
@@ -1,9 +1,11 @@
-export type WorkflowId = "shot" | "measured" | "references" | "sweeps";
+// Audit #06: measured shots and published references used to be two tabs
+// with two pickers for the same question ("what does the real world say?").
+// They now share one "Calibration" workflow and one ground-truth list.
+export type WorkflowId = "shot" | "calibration" | "sweeps";
 
 const workflows: { id: WorkflowId; label: string; description: string }[] = [
   { id: "shot", label: "Shot", description: "Author a recipe and inspect a native simulation" },
-  { id: "measured", label: "Measured data", description: "Compare one stored shot with one simulation" },
-  { id: "references", label: "References", description: "Inspect published and fixture metadata" },
+  { id: "calibration", label: "Calibration", description: "Compare a measured shot or a published reference against a simulation" },
   { id: "sweeps", label: "Sweeps", description: "Explore parameter sensitivity" },
 ];
 

--- a/web/src/features/calibration/Calibration.tsx
+++ b/web/src/features/calibration/Calibration.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+import type { MeasuredShotCatalogue, Recipe, ReferenceCatalogue, ShotResult } from "../../api/types";
+import { ReferenceShotsPanel } from "../references/ReferenceShotsPanel";
+import { GroundTruthList, type GroundTruthSelection } from "./GroundTruthList";
+import { MeasuredShotComparison } from "./MeasuredShotComparison";
+
+interface Props {
+  referenceCatalogue?: ReferenceCatalogue;
+  referenceError?: string;
+  active?: ShotResult;
+  recipe?: Recipe;
+}
+
+// Audit #06's merge point: one workflow, one ground-truth list, and whichever
+// detail view (measured comparison or reference metadata) the selection
+// calls for -- replacing the separate Measured data / References tabs.
+export function Calibration({ referenceCatalogue, referenceError, active, recipe }: Props) {
+  const [measuredCatalogue, setMeasuredCatalogue] = useState<MeasuredShotCatalogue>();
+  const [selection, setSelection] = useState<GroundTruthSelection>();
+
+  const selectedReference =
+    selection?.kind === "reference"
+      ? referenceCatalogue?.references.find((reference) => reference.id === selection.id)
+      : undefined;
+
+  return (
+    <div className="calibration">
+      {/* A reference-catalogue failure used to be its own tab's problem to
+          report; the list that would otherwise show references is now the
+          only place left to say so, regardless of what's selected. */}
+      {referenceError && (
+        <div className="error" role="alert">Reference catalogue unavailable: {referenceError}</div>
+      )}
+      <GroundTruthList
+        measuredCatalogue={measuredCatalogue}
+        referenceCatalogue={referenceCatalogue}
+        selected={selection}
+        onSelect={setSelection}
+      />
+
+      {/* Kept mounted (hidden, not unmounted) so its own catalogue fetch and
+          comparison state survive switching to look at a reference and back. */}
+      <div hidden={selection?.kind === "reference"}>
+        <MeasuredShotComparison
+          selectedId={selection?.kind === "measured" ? selection.id : undefined}
+          onSelectId={(id) => setSelection({ kind: "measured", id })}
+          onCatalogueLoaded={setMeasuredCatalogue}
+          hidePicker
+        />
+      </div>
+
+      {selection?.kind === "reference" && referenceCatalogue && (
+        <ReferenceShotsPanel
+          catalogue={
+            selectedReference
+              ? { ...referenceCatalogue, references: [selectedReference] }
+              : referenceCatalogue
+          }
+          active={active}
+          recipe={recipe}
+          error={referenceError}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/features/calibration/GroundTruthList.tsx
+++ b/web/src/features/calibration/GroundTruthList.tsx
@@ -1,0 +1,59 @@
+import type { MeasuredShotCatalogue, ReferenceCatalogue, ReferenceRecord } from "../../api/types";
+
+export type GroundTruthSelection = { kind: "measured"; id: string } | { kind: "reference"; id: string };
+
+interface Props {
+  measuredCatalogue?: MeasuredShotCatalogue;
+  referenceCatalogue?: ReferenceCatalogue;
+  selected?: GroundTruthSelection;
+  onSelect: (selection: GroundTruthSelection) => void;
+}
+
+function referenceLabel(reference: ReferenceRecord) {
+  return reference.id.replace(/^real_gagne_/, "").replace(/_/g, " ").toUpperCase();
+}
+
+// Audit #06: measured shots and published references answered the same
+// question ("what does the real world say?") from two separate tabs with two
+// pickers. One list now carries both, each row declaring what it actually
+// covers -- a measured shot has the full paired mass series a comparison
+// needs; a reference is metadata only, sometimes for a single channel.
+export function GroundTruthList({ measuredCatalogue, referenceCatalogue, selected, onSelect }: Props) {
+  const rows: { key: string; selection: GroundTruthSelection; name: string; caption: string }[] = [
+    ...(measuredCatalogue?.measured_shots.map((shot) => ({
+      key: `measured:${shot.id}`,
+      selection: { kind: "measured" as const, id: shot.id },
+      name: shot.id,
+      caption: `measured · ${shot.synthetic ? "synthetic" : "real"}${shot.machine ? ` · ${shot.machine}` : ""}`,
+    })) ?? []),
+    ...(referenceCatalogue?.references.map((reference) => ({
+      key: `reference:${reference.id}`,
+      selection: { kind: "reference" as const, id: reference.id },
+      name: referenceLabel(reference),
+      caption: "published · metadata only",
+    })) ?? []),
+  ];
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="ground-truth-list" aria-label="Ground truth: measured shots and published references">
+      {rows.map((row) => {
+        const isSelected =
+          selected?.kind === row.selection.kind && selected.id === row.selection.id;
+        return (
+          <button
+            key={row.key}
+            type="button"
+            className={`ground-truth-row${isSelected ? " selected" : ""}`}
+            aria-pressed={isSelected}
+            onClick={() => onSelect(row.selection)}
+          >
+            <span className="ground-truth-name">{row.name}</span>
+            <span className="ground-truth-caption">{row.caption}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/features/calibration/MeasuredShotComparison.test.tsx
+++ b/web/src/features/calibration/MeasuredShotComparison.test.tsx
@@ -1,5 +1,5 @@
 import { http, HttpResponse, delay } from "msw";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
@@ -61,6 +61,31 @@ describe("MeasuredShotComparison: running a comparison", () => {
     await screen.findByText(/mass rmse/i);
     expect(requests).toBe(1);
     expect(seenQuery).toBe("default-v1");
+  });
+
+  it("shows a cursor readout with measured/simulated/residual values on hover", async () => {
+    // Regression test: the comparison canvas never wired onCursorChange or
+    // cursorTimeSeconds into AnalysisCanvas at all, so hovering it did
+    // nothing -- unlike ChartStack, which had the callback wired but never
+    // fed the value back in.
+    useCatalogue();
+    server.use(
+      http.get("/api/v1/measured-shots/:id/compare", () => HttpResponse.json(makeMeasuredShotComparison())),
+    );
+    const user = userEvent.setup();
+    const { container } = render(<MeasuredShotComparison />);
+    await screen.findByLabelText(/measured shot/i);
+    await user.click(screen.getByRole("button", { name: /compare with default-v1/i }));
+    await screen.findByText(/mass rmse/i);
+
+    const svg = container.querySelector(".analysis-canvas-svg")!;
+    fireEvent.mouseMove(svg, { clientX: 50 });
+
+    const readout = container.querySelector(".cursor-readout");
+    expect(readout).toBeInTheDocument();
+    expect(readout!.textContent).toMatch(/measured/i);
+    expect(readout!.textContent).toMatch(/simulated/i);
+    expect(readout!.textContent).toMatch(/residual/i);
   });
 
   it("shows correctly-signed residuals and units for optional measurement fields", async () => {

--- a/web/src/features/calibration/MeasuredShotComparison.tsx
+++ b/web/src/features/calibration/MeasuredShotComparison.tsx
@@ -1,19 +1,12 @@
 import { useEffect, useId, useRef, useState } from "react";
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
 
 import { api } from "../../api/client";
 import type {
   MeasuredShotCatalogue,
   MeasuredShotComparison as Comparison,
 } from "../../api/types";
+import { AnalysisCanvas, type CanvasSeries } from "../shared/AnalysisCanvas";
+import { TRACE_STYLES } from "../../theme/traceStyles";
 
 const DEFAULT_COEFFICIENT_SELECTOR = "default-v1";
 
@@ -25,106 +18,86 @@ function formatMetric(value: number, digits: number, unit: string) {
   );
 }
 
-function ComparisonTooltip({ active, payload, label }: any) {
-  if (!active || !payload?.length) return null;
+// Audit #03: mass and residual used to be two independent recharts
+// LineCharts with separate axes/tooltips, so reading a residual spike
+// against the mass curve that produced it meant comparing two plots by eye.
+// One AnalysisCanvas now carries both on a shared time axis and cursor.
+function MeasuredComparisonCanvas({ pairedSeries }: { pairedSeries: Comparison["paired_series"] }) {
+  // No PuckView-equivalent to sync with here, so this cursor is entirely
+  // local to the canvas -- unlike ChartStack, which lifts it into
+  // ShotWorkspace to also drive the puck animation.
+  const [cursorTimeSeconds, setCursorTimeSeconds] = useState<number>();
+  const measured: CanvasSeries = {
+    key: "measured",
+    label: "measured",
+    color: TRACE_STYLES.measured.color,
+    width: TRACE_STYLES.measured.width,
+    format: (value) => `${value.toFixed(3)} g`,
+    points: pairedSeries.map((row) => ({ time: row.time_s, value: row.measured_mass_g })),
+  };
+  const simulated: CanvasSeries = {
+    key: "simulated",
+    label: "simulated",
+    color: TRACE_STYLES.simulated.color,
+    width: TRACE_STYLES.simulated.width,
+    dash: TRACE_STYLES.simulated.dash,
+    format: (value) => `${value.toFixed(3)} g`,
+    points: pairedSeries.map((row) => ({ time: row.time_s, value: row.simulated_mass_g })),
+  };
+  const residual: CanvasSeries = {
+    key: "residual",
+    label: "residual",
+    color: TRACE_STYLES.residual.color,
+    width: TRACE_STYLES.residual.width,
+    format: (value) => `${value.toFixed(3)} g`,
+    points: pairedSeries.map((row) => ({ time: row.time_s, value: row.residual_g })),
+  };
+
   return (
-    <div className="tooltip">
-      <div className="t">t = {Number(label).toFixed(2)} s</div>
-      {payload.map((entry: any) => (
-        <div key={entry.dataKey} style={{ color: entry.color }}>
-          {entry.name}: {Number(entry.value).toFixed(3)} g
-        </div>
-      ))}
-    </div>
+    <>
+      <div className="analysis-legend" aria-hidden="true">
+        <span className="analysis-legend-item">
+          <span className="analysis-legend-swatch" style={{ borderTopColor: measured.color, borderTopStyle: "solid" }} />
+          measured
+        </span>
+        <span className="analysis-legend-item">
+          <span className="analysis-legend-swatch" style={{ borderTopColor: simulated.color, borderTopStyle: "dashed" }} />
+          simulated
+        </span>
+        <span className="analysis-legend-item">
+          <span className="analysis-legend-swatch" style={{ borderTopColor: residual.color, borderTopStyle: "solid" }} />
+          residual
+        </span>
+      </div>
+      <AnalysisCanvas
+        ariaLabel="Measured and simulated beverage mass, with the residual in its own lane, over measured sample time"
+        series={[measured, simulated]}
+        residual={residual}
+        residualLabel="Residual · measured − simulated"
+        cursorTimeSeconds={cursorTimeSeconds}
+        onCursorChange={setCursorTimeSeconds}
+      />
+    </>
   );
 }
 
-function ComparisonChart({
-  title,
-  data,
-  residual = false,
-}: {
-  title: string;
-  data: Comparison["paired_series"];
-  residual?: boolean;
-}) {
-  return (
-    <div className="comparison-chart" role="img" aria-label={`${title} over measured sample time`}>
-      <h4>{title}</h4>
-      <ResponsiveContainer width="100%" height={210}>
-        <LineChart data={data} margin={{ top: 6, right: 14, bottom: 8, left: 4 }}>
-          <CartesianGrid stroke="#3a302a" strokeDasharray="2 4" />
-          <XAxis
-            dataKey="time_s"
-            type="number"
-            domain={["dataMin", "dataMax"]}
-            tick={{ fill: "#a2938a", fontSize: 11 }}
-            stroke="#3a302a"
-            label={{
-              value: "measured sample time (s)",
-              position: "insideBottom",
-              offset: -5,
-              fill: "#a2938a",
-              fontSize: 11,
-            }}
-          />
-          <YAxis
-            tick={{ fill: "#a2938a", fontSize: 11 }}
-            stroke="#3a302a"
-            width={58}
-            label={{
-              value: residual ? "residual (g)" : "mass (g)",
-              angle: -90,
-              position: "insideLeft",
-              offset: 12,
-              fill: "#a2938a",
-              fontSize: 11,
-            }}
-          />
-          <Tooltip content={<ComparisonTooltip />} />
-          {residual ? (
-            <Line
-              type="linear"
-              dataKey="residual_g"
-              name="measured - simulated"
-              stroke="#d9584a"
-              strokeWidth={1.8}
-              dot={false}
-              isAnimationActive={false}
-            />
-          ) : (
-            <>
-              <Line
-                type="linear"
-                dataKey="measured_mass_g"
-                name="measured"
-                stroke="#6fb3c8"
-                strokeWidth={2}
-                dot={{ r: 2 }}
-                isAnimationActive={false}
-              />
-              <Line
-                type="linear"
-                dataKey="simulated_mass_g"
-                name="simulated"
-                stroke="#d98b4a"
-                strokeWidth={1.8}
-                strokeDasharray="5 3"
-                dot={false}
-                isAnimationActive={false}
-              />
-            </>
-          )}
-        </LineChart>
-      </ResponsiveContainer>
-    </div>
-  );
+// Audit #06: selection can be owned by a parent (GroundTruthList, so a
+// measured-shot row in the merged ground-truth list drives this view) or, by
+// default, entirely internally -- every existing standalone use and test
+// keeps working unchanged.
+interface Props {
+  selectedId?: string;
+  onSelectId?: (id: string) => void;
+  onCatalogueLoaded?: (catalogue: MeasuredShotCatalogue) => void;
+  hidePicker?: boolean;
 }
 
-export function MeasuredShotComparison() {
+export function MeasuredShotComparison({ selectedId: controlledId, onSelectId, onCatalogueLoaded, hidePicker = false }: Props = {}) {
   const selectId = useId();
   const [catalogue, setCatalogue] = useState<MeasuredShotCatalogue>();
-  const [selectedId, setSelectedId] = useState("");
+  const [internalSelectedId, setInternalSelectedId] = useState("");
+  const selectedId = controlledId ?? internalSelectedId;
+  const setSelectedId = onSelectId ?? setInternalSelectedId;
   const [catalogueError, setCatalogueError] = useState<string>();
   const [comparison, setComparison] = useState<Comparison>();
   const [comparisonError, setComparisonError] = useState<string>();
@@ -138,7 +111,8 @@ export function MeasuredShotComparison() {
       .measuredShots(controller.signal)
       .then((body) => {
         setCatalogue(body);
-        setSelectedId(body.measured_shots[0]?.id ?? "");
+        onCatalogueLoaded?.(body);
+        if (controlledId === undefined) setSelectedId(body.measured_shots[0]?.id ?? "");
       })
       .catch((failure) => {
         if (failure instanceof DOMException && failure.name === "AbortError") return;
@@ -215,16 +189,18 @@ export function MeasuredShotComparison() {
       )}
       {catalogue && catalogue.measured_shots.length > 0 && (
         <div className="comparison-controls">
-          <div>
-            <label htmlFor={selectId}>Measured shot</label>
-            <select id={selectId} value={selectedId} onChange={(event) => selectShot(event.target.value)}>
-              {catalogue.measured_shots.map((shot) => (
-                <option value={shot.id} key={shot.id}>
-                  {shot.id}{shot.synthetic ? " (synthetic)" : " (real)"}
-                </option>
-              ))}
-            </select>
-          </div>
+          {!hidePicker && (
+            <div>
+              <label htmlFor={selectId}>Measured shot</label>
+              <select id={selectId} value={selectedId} onChange={(event) => selectShot(event.target.value)}>
+                {catalogue.measured_shots.map((shot) => (
+                  <option value={shot.id} key={shot.id}>
+                    {shot.id}{shot.synthetic ? " (synthetic)" : " (real)"}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <button type="button" onClick={compare} disabled={!selectedId || loadingComparison}>
             {loadingComparison ? "Comparing..." : "Compare with default-v1"}
           </button>
@@ -296,10 +272,7 @@ export function MeasuredShotComparison() {
           </div>
 
           {comparison.paired_series.length > 0 ? (
-            <div className="comparison-charts">
-              <ComparisonChart title="Measured and simulated beverage mass" data={comparison.paired_series} />
-              <ComparisonChart title="Beverage-mass residual" data={comparison.paired_series} residual />
-            </div>
+            <MeasuredComparisonCanvas pairedSeries={comparison.paired_series} />
           ) : (
             <p className="note">This shot has no paired mass-series points to plot.</p>
           )}

--- a/web/src/features/shared/AnalysisCanvas.tsx
+++ b/web/src/features/shared/AnalysisCanvas.tsx
@@ -1,0 +1,266 @@
+import { useMemo, type MouseEvent } from "react";
+
+import { CursorReadout, type CursorReadoutRow } from "./CursorReadout";
+
+export interface CanvasPoint {
+  time: number;
+  value: number;
+}
+
+export interface CanvasSeries {
+  key: string;
+  label: string;
+  color: string;
+  width?: number;
+  dash?: string;
+  /** Overlay/comparison traces render lighter so the primary run stays legible. */
+  opacity?: number;
+  format?: (value: number) => string;
+  points: CanvasPoint[];
+}
+
+export interface CanvasMarker {
+  time: number;
+  label: string;
+  color: string;
+}
+
+interface Props {
+  /** Accessible summary for the well -- recharts spoke for itself via its own
+   * ARIA plumbing; a hand-rolled SVG has none, so this is load-bearing. */
+  ariaLabel: string;
+  series: CanvasSeries[];
+  residual?: CanvasSeries;
+  residualLabel?: string;
+  markers?: CanvasMarker[];
+  preInfusionEnd?: number;
+  cursorTimeSeconds?: number;
+  onCursorChange?: (time: number | undefined) => void;
+  height?: number;
+}
+
+// Audit #03/#04: this single well replaces per-signal chart-selector charts
+// (Shot) and separate mass/residual LineCharts (Calibration). Every series
+// shares one time axis and one cursor; each is normalized to its own value
+// range within the plot band since pressure/flow/mass/temperature have no
+// common unit -- exact values live in the CursorReadout and the data table,
+// not on a literal shared y-axis.
+const WIDTH = 1000;
+const MAIN_HEIGHT = 330;
+const RESIDUAL_HEIGHT = 90;
+const PAD = 10;
+
+function timeDomain(allSeries: CanvasSeries[]): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const line of allSeries) {
+    for (const point of line.points) {
+      if (point.time < min) min = point.time;
+      if (point.time > max) max = point.time;
+    }
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min >= max) {
+    return [0, Number.isFinite(max) && max > 0 ? max : 1];
+  }
+  return [min, max];
+}
+
+function valueDomain(points: CanvasPoint[]): [number, number] {
+  if (points.length === 0) return [0, 1];
+  let min = points[0].value;
+  let max = points[0].value;
+  for (const point of points) {
+    if (point.value < min) min = point.value;
+    if (point.value > max) max = point.value;
+  }
+  if (min === max) {
+    min -= 1;
+    max += 1;
+  }
+  return [min, max];
+}
+
+function buildPath(
+  points: CanvasPoint[],
+  tMin: number,
+  tMax: number,
+  vMin: number,
+  vMax: number,
+  top: number,
+  bottom: number,
+): string {
+  if (points.length === 0) return "";
+  const sorted = [...points].sort((a, b) => a.time - b.time);
+  const x = (t: number) => (tMax === tMin ? 0 : ((t - tMin) / (tMax - tMin)) * WIDTH);
+  const y = (v: number) =>
+    vMax === vMin ? (top + bottom) / 2 : bottom - ((v - vMin) / (vMax - vMin)) * (bottom - top);
+  return sorted.map((point, index) => `${index === 0 ? "M" : "L"}${x(point.time).toFixed(2)},${y(point.value).toFixed(2)}`).join(" ");
+}
+
+function nearestPoint(points: CanvasPoint[], time: number): CanvasPoint | undefined {
+  let best: CanvasPoint | undefined;
+  let bestDelta = Infinity;
+  for (const point of points) {
+    const delta = Math.abs(point.time - time);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      best = point;
+    }
+  }
+  return best;
+}
+
+export function AnalysisCanvas({
+  ariaLabel,
+  series,
+  residual,
+  residualLabel,
+  markers = [],
+  preInfusionEnd,
+  cursorTimeSeconds,
+  onCursorChange,
+  height,
+}: Props) {
+  const allSeries = residual ? [...series, residual] : series;
+  const [tMin, tMax] = useMemo(() => timeDomain(allSeries), [allSeries]);
+  const totalHeight = MAIN_HEIGHT + (residual ? RESIDUAL_HEIGHT : 0);
+
+  const handleMove = (event: MouseEvent<SVGSVGElement>) => {
+    if (!onCursorChange) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    onCursorChange(tMin + ratio * (tMax - tMin));
+  };
+
+  const cursorX =
+    cursorTimeSeconds !== undefined && tMax > tMin
+      ? ((cursorTimeSeconds - tMin) / (tMax - tMin)) * WIDTH
+      : undefined;
+  const preInfusionX =
+    preInfusionEnd !== undefined && tMax > tMin
+      ? ((preInfusionEnd - tMin) / (tMax - tMin)) * WIDTH
+      : undefined;
+
+  const readoutRows: CursorReadoutRow[] =
+    cursorTimeSeconds === undefined
+      ? []
+      : allSeries.map((line) => {
+          const point = nearestPoint(line.points, cursorTimeSeconds);
+          return {
+            key: line.key,
+            label: line.label,
+            color: line.color,
+            formatted: point ? (line.format ? line.format(point.value) : point.value.toFixed(2)) : "—",
+          };
+        });
+
+  return (
+    <div className="chart-card analysis-canvas" role="img" aria-label={ariaLabel}>
+      <div className="analysis-canvas-well" style={{ height: height ?? 360 }}>
+        <svg
+          viewBox={`0 0 ${WIDTH} ${totalHeight}`}
+          preserveAspectRatio="none"
+          className="analysis-canvas-svg"
+          onMouseMove={handleMove}
+          onMouseLeave={() => onCursorChange?.(undefined)}
+        >
+          {[0.2, 0.4, 0.6, 0.8].map((fraction) => (
+            <line
+              key={`h-${fraction}`}
+              x1={0} y1={MAIN_HEIGHT * fraction} x2={WIDTH} y2={MAIN_HEIGHT * fraction}
+              className="analysis-gridline"
+            />
+          ))}
+          {[0.25, 0.5, 0.75].map((fraction) => (
+            <line
+              key={`v-${fraction}`}
+              x1={WIDTH * fraction} y1={0} x2={WIDTH * fraction} y2={MAIN_HEIGHT}
+              className="analysis-gridline"
+            />
+          ))}
+
+          {preInfusionX !== undefined && (
+            <>
+              <rect x={0} y={0} width={preInfusionX} height={MAIN_HEIGHT} className="analysis-preinfusion" />
+              <line
+                x1={preInfusionX} y1={0} x2={preInfusionX} y2={MAIN_HEIGHT}
+                className="analysis-preinfusion-divider"
+              />
+            </>
+          )}
+
+          {markers.map((marker) => {
+            const x = tMax > tMin ? ((marker.time - tMin) / (tMax - tMin)) * WIDTH : 0;
+            return (
+              <line
+                key={`marker-${marker.label}-${marker.time}`}
+                x1={x} y1={0} x2={x} y2={MAIN_HEIGHT}
+                stroke={marker.color} strokeDasharray="3 3" strokeWidth={1} opacity={0.65}
+              />
+            );
+          })}
+
+          {series.map((line) => {
+            const [vMin, vMax] = valueDomain(line.points);
+            return (
+              <path
+                key={line.key}
+                data-series={line.key}
+                d={buildPath(line.points, tMin, tMax, vMin, vMax, PAD, MAIN_HEIGHT - PAD)}
+                fill="none"
+                stroke={line.color}
+                strokeWidth={line.width ?? 2}
+                strokeDasharray={line.dash}
+                opacity={line.opacity ?? 1}
+              />
+            );
+          })}
+
+          {residual && (
+            <>
+              <line
+                x1={0} y1={MAIN_HEIGHT + RESIDUAL_HEIGHT / 2} x2={WIDTH} y2={MAIN_HEIGHT + RESIDUAL_HEIGHT / 2}
+                className="analysis-zero-rule" strokeDasharray="3 4"
+              />
+              {(() => {
+                const [rMin, rMax] = valueDomain(residual.points);
+                const bound = Math.max(Math.abs(rMin), Math.abs(rMax)) || 1;
+                return (
+                  <path
+                    data-series={residual.key}
+                    d={buildPath(
+                      residual.points, tMin, tMax, -bound, bound,
+                      MAIN_HEIGHT + 6, MAIN_HEIGHT + RESIDUAL_HEIGHT - 6,
+                    )}
+                    fill="none"
+                    stroke={residual.color}
+                    strokeWidth={residual.width ?? 1.5}
+                  />
+                );
+              })()}
+            </>
+          )}
+
+          {cursorX !== undefined && (
+            <line x1={cursorX} y1={0} x2={cursorX} y2={totalHeight} className="analysis-cursor" />
+          )}
+        </svg>
+
+        {residual && residualLabel && (
+          <div className="analysis-residual-label" style={{ top: `${(MAIN_HEIGHT / totalHeight) * 100}%` }}>
+            {residualLabel}
+          </div>
+        )}
+
+        {cursorTimeSeconds !== undefined && cursorX !== undefined && (
+          <CursorReadout
+            timeSeconds={cursorTimeSeconds}
+            xPercent={(cursorX / WIDTH) * 100}
+            rows={readoutRows}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/shared/CursorReadout.tsx
+++ b/web/src/features/shared/CursorReadout.tsx
@@ -1,0 +1,40 @@
+export interface CursorReadoutRow {
+  key: string;
+  label: string;
+  color: string;
+  formatted: string;
+}
+
+interface Props {
+  timeSeconds: number;
+  /** 0-100, the cursor's horizontal position within the well. */
+  xPercent: number;
+  rows: CursorReadoutRow[];
+}
+
+// Floating box anchored to the cursor, matching the well's legend order --
+// audit #08/the Calibration frame's rule that a reader never has to remap
+// which row is which channel. Flips to the cursor's left past the midpoint
+// so it never runs off the well's right edge.
+export function CursorReadout({ timeSeconds, xPercent, rows }: Props) {
+  const anchorRight = xPercent > 55;
+  return (
+    <div
+      className="cursor-readout"
+      style={
+        anchorRight
+          ? { right: `${100 - xPercent}%`, marginRight: 10 }
+          : { left: `${xPercent}%`, marginLeft: 10 }
+      }
+    >
+      <div className="cursor-readout-time">t = {timeSeconds.toFixed(2)} s</div>
+      <div className="cursor-readout-rule" />
+      {rows.map((row) => (
+        <div key={row.key} className="cursor-readout-row">
+          <span className="cursor-readout-label">{row.label}</span>
+          <span style={{ color: row.color }}>{row.formatted}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/features/shot/ChartStack.test.tsx
+++ b/web/src/features/shot/ChartStack.test.tsx
@@ -4,20 +4,20 @@ import { describe, expect, it, vi } from "vitest";
 import { makeShotResult } from "../../test/fixtures/shotResult";
 import { ChartStack } from "./ChartStack";
 
-describe("ChartStack: series and chart summaries", () => {
-  it("switches the coordinated chart between tracked quantities with accessible summaries", () => {
+describe("ChartStack: all channels drawn together", () => {
+  it("draws pressure, flow, mass and temperature simultaneously with no signal selector", () => {
     const result = makeShotResult();
     render(<ChartStack result={result} comparisons={[]} onCursorChange={vi.fn()} />);
 
-    expect(screen.getByRole("img", { name: /^Commanded pressure \(bar\): commanded pressure/i })).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Signal"), { target: { value: "flow" } });
-    expect(screen.getByRole("img", { name: /^Computed flow \(ml\/s\): flow/i })).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Signal"), { target: { value: "temperature" } });
-    expect(screen.getByRole("img", { name: /^Temperatures.*inlet, puck/i })).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Signal"), { target: { value: "mass" } });
-    expect(screen.getByRole("img", { name: /^Beverage mass \(g\): beverage mass/i })).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Signal"), { target: { value: "strength" } });
-    expect(screen.getByRole("img", { name: /^Strength and extraction.*TDS, extraction yield/i })).toBeInTheDocument();
+    // Audit #04: there is no more single-signal <select> gating the other
+    // three channels off screen -- one well, one accessible summary, all
+    // four channels named in it.
+    expect(screen.queryByLabelText("Signal")).not.toBeInTheDocument();
+    const chart = screen.getByRole("img", { name: /^Shot analysis: pressure, flow, mass, temperature/i });
+    expect(chart).toBeInTheDocument();
+    for (const key of ["pressure", "flow", "mass", "temperature"]) {
+      expect(chart.querySelector(`path[data-series="${key}"]`)).toBeInTheDocument();
+    }
   });
 
   it("adds an overlay series per comparison run, labelled with its run id, up to 3 total runs", () => {
@@ -25,23 +25,44 @@ describe("ChartStack: series and chart summaries", () => {
     const comparisons = [makeShotResult(), makeShotResult(), makeShotResult()];
     render(<ChartStack result={result} comparisons={comparisons} onCursorChange={vi.fn()} />);
 
-    fireEvent.change(screen.getByLabelText("Signal"), { target: { value: "mass" } });
-    const massChart = screen.getByRole("img", { name: /^Beverage mass/i });
+    const chart = screen.getByRole("img", { name: /^Shot analysis/i });
     // Only the first 2 comparisons are drawn (3 total runs including the
     // primary), each named by a slice of its own run id.
-    expect(massChart.getAttribute("aria-label")).toContain(comparisons[0].manifest.run_id.slice(5, 11));
-    expect(massChart.getAttribute("aria-label")).toContain(comparisons[1].manifest.run_id.slice(5, 11));
-    expect(massChart.getAttribute("aria-label")).not.toContain(comparisons[2].manifest.run_id.slice(5, 11));
+    expect(chart.getAttribute("aria-label")).toContain(comparisons[0].manifest.run_id.slice(5, 11));
+    expect(chart.getAttribute("aria-label")).toContain(comparisons[1].manifest.run_id.slice(5, 11));
+    expect(chart.getAttribute("aria-label")).not.toContain(comparisons[2].manifest.run_id.slice(5, 11));
+    expect(chart.querySelector(`path[data-series="mass_${comparisons[0].manifest.run_id}"]`)).toBeInTheDocument();
+  });
+
+  it("keeps a pinned run's dash pattern stable when another pinned run is removed (audit #07)", () => {
+    const result = makeShotResult();
+    const first = makeShotResult();
+    const second = makeShotResult();
+    const { rerender } = render(
+      <ChartStack result={result} comparisons={[first, second]} onCursorChange={vi.fn()} />,
+    );
+    const dashBefore = screen
+      .getByRole("img", { name: /^Shot analysis/i })
+      .querySelector(`path[data-series="pressure_${second.manifest.run_id}"]`)
+      ?.getAttribute("stroke-dasharray");
+
+    rerender(<ChartStack result={result} comparisons={[second]} onCursorChange={vi.fn()} />);
+    const dashAfter = screen
+      .getByRole("img", { name: /^Shot analysis/i })
+      .querySelector(`path[data-series="pressure_${second.manifest.run_id}"]`)
+      ?.getAttribute("stroke-dasharray");
+
+    expect(dashAfter).toBe(dashBefore);
   });
 
   it("includes a pre-infusion marker only when preInfusionEnd is given", () => {
     const result = makeShotResult({ target_mass_reached: false });
     const { rerender } = render(<ChartStack result={result} comparisons={[]} onCursorChange={vi.fn()} />);
-    const chartWithout = screen.getByRole("img", { name: /^Commanded pressure/i });
+    const chartWithout = screen.getByRole("img", { name: /^Shot analysis/i });
     expect(chartWithout.getAttribute("aria-label")).not.toMatch(/marked event/);
 
     rerender(<ChartStack result={result} comparisons={[]} preInfusionEnd={10} onCursorChange={vi.fn()} />);
-    const chartWith = screen.getByRole("img", { name: /^Commanded pressure/i });
+    const chartWith = screen.getByRole("img", { name: /^Shot analysis/i });
     expect(chartWith.getAttribute("aria-label")).toMatch(/1 marked event/);
   });
 
@@ -54,7 +75,7 @@ describe("ChartStack: series and chart summaries", () => {
       ],
     });
     render(<ChartStack result={result} comparisons={[]} onCursorChange={vi.fn()} />);
-    const chart = screen.getByRole("img", { name: /^Commanded pressure/i });
+    const chart = screen.getByRole("img", { name: /^Shot analysis/i });
     // target mass marker + 2 warnings = 3.
     expect(chart.getAttribute("aria-label")).toMatch(/3 marked events/);
   });
@@ -64,17 +85,40 @@ describe("ChartStack: shared cursor callback", () => {
   it("calls onCursorChange with a time on mouse move and undefined on mouse leave", () => {
     const onCursorChange = vi.fn();
     const result = makeShotResult();
-    render(<ChartStack result={result} comparisons={[]} onCursorChange={onCursorChange} />);
+    const { container } = render(
+      <ChartStack result={result} comparisons={[]} onCursorChange={onCursorChange} />,
+    );
 
-    const chart = screen.getByRole("img", { name: /^Commanded pressure/i });
-    // Recharts attaches its mouse handlers to the chart's inner surface;
-    // firing directly on the chart-card container still bubbles to them.
-    fireEvent.mouseMove(chart);
-    fireEvent.mouseLeave(chart);
-    // Both handlers exist and are wired without throwing; Recharts' own
-    // activeLabel computation from real pixel geometry belongs to Playwright
-    // (web/e2e/), not this jsdom-stubbed layout.
+    const svg = container.querySelector(".analysis-canvas-svg")!;
+    fireEvent.mouseMove(svg, { clientX: 50 });
+    fireEvent.mouseLeave(svg);
+    expect(onCursorChange).toHaveBeenCalledWith(undefined);
     expect(onCursorChange).not.toHaveBeenCalledWith(NaN);
+  });
+
+  it("renders the cursor readout, with pinned-run values, once cursorTimeSeconds is fed back in", () => {
+    // Regression test: ChartStack used to forward onCursorChange to
+    // AnalysisCanvas but never accepted cursorTimeSeconds back from its
+    // parent, so the readout box built by that value never rendered even
+    // though the mouse-move callback fired correctly.
+    const result = makeShotResult();
+    const comparison = makeShotResult();
+    const { container } = render(
+      <ChartStack
+        result={result}
+        comparisons={[comparison]}
+        cursorTimeSeconds={result.samples[1].time_s}
+        onCursorChange={vi.fn()}
+      />,
+    );
+
+    const readout = container.querySelector(".cursor-readout");
+    expect(readout).toBeInTheDocument();
+    expect(readout).toHaveTextContent(/t = /);
+    // One row per primary channel plus one per overlay channel for the
+    // pinned comparison run.
+    expect(container.querySelectorAll(".cursor-readout-row").length).toBeGreaterThanOrEqual(8);
+    expect(readout!.textContent).toContain(comparison.manifest.run_id.slice(5, 11));
   });
 });
 
@@ -97,11 +141,11 @@ describe("ChartStack: differing sample intervals between overlay runs", () => {
     const { container } = render(
       <ChartStack result={result} comparisons={[comparison]} onCursorChange={vi.fn()} />,
     );
-    fireEvent.change(screen.getByLabelText("Signal"), { target: { value: "mass" } });
 
-    const lines = container.querySelectorAll(".recharts-line-curve");
-    expect(lines).toHaveLength(2);
-    expect(Array.from(lines).every((line) => line.getAttribute("d"))).toBe(true);
+    const massPath = container.querySelector(`path[data-series="mass"]`);
+    const overlayMassPath = container.querySelector(`path[data-series="mass_${comparison.manifest.run_id}"]`);
+    expect(massPath?.getAttribute("d")).toBeTruthy();
+    expect(overlayMassPath?.getAttribute("d")).toBeTruthy();
   });
 
   it("renders a current-run data table on demand", () => {

--- a/web/src/features/shot/ChartStack.tsx
+++ b/web/src/features/shot/ChartStack.tsx
@@ -1,152 +1,68 @@
-import { useId, useState } from "react";
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-
 import type { ShotResult } from "../../api/types";
-
-interface Series {
-  key: string;
-  label: string;
-  color: string;
-  dashed?: boolean;
-}
+import { AnalysisCanvas, type CanvasSeries } from "../shared/AnalysisCanvas";
+import { overlayDashFor, TRACE_STYLES } from "../../theme/traceStyles";
 
 interface Props {
   result: ShotResult;
   comparisons: ShotResult[];
   preInfusionEnd?: number;
+  cursorTimeSeconds?: number;
   onCursorChange: (time?: number) => void;
 }
 
-const palette = ["#d98b4a", "#6fb3c8", "#9c8ad0", "#78b06a"];
-
-// Recharts' syncId gives every chart in the stack one shared hover cursor and
-// one shared time axis, which is the requirement in 12.5 and the acceptance
-// criterion for FR-06.
-const SYNC_ID = "espressolab-shot";
-
-type ChartKey = "pressure" | "flow" | "temperature" | "mass" | "strength";
-
-function ShotTooltip({ active, payload, label }: any) {
-  if (!active || !payload?.length) return null;
-  return (
-    <div className="tooltip">
-      <div className="t">t = {Number(label).toFixed(2)} s</div>
-      {payload.map((entry: any) => (
-        <div key={entry.name} style={{ color: entry.color }}>
-          {entry.name}: {Number(entry.value).toFixed(2)}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function Chart({
-  title,
-  data,
-  series,
-  unit,
-  markers,
-  onCursorChange,
-}: {
-  title: string;
-  data: Record<string, number>[];
-  series: Series[];
+interface Channel {
+  key: "pressure" | "flow" | "mass" | "temperature";
+  label: string;
   unit: string;
-  markers: { time: number; label: string; color: string }[];
-  onCursorChange: (time?: number) => void;
-}) {
-  // Recharts renders an SVG with no text alternative of its own, so a screen
-  // reader sees the chart card's heading and then nothing about what the
-  // lines actually show. A one-sentence summary -- the series names and
-  // however many timeline markers this chart carries -- fills that gap
-  // without trying to narrate every data point.
-  const summary =
-    `${title}: ${series.map((line) => line.label).join(", ")} over the shot's timeline` +
-    (markers.length > 0 ? `, with ${markers.length} marked event${markers.length === 1 ? "" : "s"}.` : ".");
-
-  return (
-    <div className="chart-card" role="img" aria-label={summary}>
-      <h3>{title}</h3>
-      <ResponsiveContainer width="100%" height={170}>
-        <LineChart
-          data={data}
-          syncId={SYNC_ID}
-          margin={{ top: 4, right: 12, bottom: 4, left: 4 }}
-          onMouseMove={(state: any) => onCursorChange(state?.activeLabel)}
-          onMouseLeave={() => onCursorChange(undefined)}
-        >
-          <CartesianGrid stroke="#3a302a" strokeDasharray="2 4" />
-          <XAxis
-            dataKey="time_s" type="number" domain={["dataMin", "dataMax"]}
-            tick={{ fill: "#a2938a", fontSize: 11 }} stroke="#3a302a"
-            label={{ value: "time (s)", position: "insideBottom", offset: -2, fill: "#a2938a", fontSize: 11 }}
-          />
-          <YAxis
-            tick={{ fill: "#a2938a", fontSize: 11 }} stroke="#3a302a" width={64}
-            label={{ value: unit, angle: -90, position: "insideLeft", offset: 12,
-                     fill: "#a2938a", fontSize: 11 }}
-          />
-          <Tooltip content={<ShotTooltip />} />
-          {markers.map((marker) => (
-            <ReferenceLine
-              key={marker.label + marker.time}
-              x={marker.time}
-              stroke={marker.color}
-              strokeDasharray="3 3"
-              label={{ value: marker.label, fill: marker.color, fontSize: 10, position: "top" }}
-            />
-          ))}
-          {series.map((line) => (
-            <Line
-              key={line.key} type="monotone" dataKey={line.key} name={line.label}
-              stroke={line.color} strokeWidth={1.8} dot={false} isAnimationActive={false}
-              connectNulls
-              strokeDasharray={line.dashed ? "4 3" : undefined}
-            />
-          ))}
-        </LineChart>
-      </ResponsiveContainer>
-    </div>
-  );
+  extract: (sample: ShotResult["samples"][number]) => number;
 }
 
-export function ChartStack({ result, comparisons, preInfusionEnd, onCursorChange }: Props) {
-  const [selectedChart, setSelectedChart] = useState<ChartKey>("pressure");
-  const selectorId = useId();
-  const runs = [result, ...comparisons].slice(0, 3);
-  const rowsByTime = new Map<number, Record<string, number>>();
-  for (const sample of result.samples) rowsByTime.set(sample.time_s, { ...sample });
-  runs.slice(1).forEach((run, comparisonIndex) => {
-    const runIndex = comparisonIndex + 1;
-    for (const sample of run.samples) {
-      const row = rowsByTime.get(sample.time_s) ?? { time_s: sample.time_s };
-      row[`pressure_bar_${runIndex}`] = sample.pressure_bar;
-      row[`flow_ml_s_${runIndex}`] = sample.flow_ml_s;
-      row[`beverage_mass_g_${runIndex}`] = sample.beverage_mass_g;
-      row[`extraction_yield_percent_${runIndex}`] = sample.extraction_yield_percent;
-      row[`puck_temperature_c_${runIndex}`] = sample.puck_temperature_c;
-      row[`tds_percent_${runIndex}`] = sample.tds_percent;
-      rowsByTime.set(sample.time_s, row);
-    }
-  });
-  const data = [...rowsByTime.values()].sort((left, right) => left.time_s - right.time_s);
+// The four traces the Hi-Fi legend names (pressure/flow/mass/temperature),
+// always drawn together -- audit #04 retired the single-signal <select> that
+// used to gate the other three off screen.
+const CHANNELS: Channel[] = [
+  { key: "pressure", label: "pressure", unit: " bar", extract: (s) => s.pressure_bar },
+  { key: "flow", label: "flow", unit: " ml/s", extract: (s) => s.flow_ml_s },
+  { key: "mass", label: "mass", unit: " g", extract: (s) => s.beverage_mass_g },
+  { key: "temperature", label: "temperature", unit: " °C", extract: (s) => s.puck_temperature_c },
+];
 
-  const overlay = (key: string, label: string): Series[] =>
-    runs.slice(1).map((run, index) => ({
-      key: `${key}_${index + 1}`,
-      label: `${label} · ${run.manifest.run_id.slice(5, 11)}`,
-      color: palette[index + 1],
-      dashed: true,
-    }));
+const MAX_RUNS = 3;
+
+export function ChartStack({ result, comparisons, preInfusionEnd, cursorTimeSeconds, onCursorChange }: Props) {
+  const runs = [result, ...comparisons].slice(0, MAX_RUNS);
+  const overlayRuns = runs.slice(1);
+
+  const series: CanvasSeries[] = CHANNELS.map((channel) => {
+    const style = TRACE_STYLES[channel.key];
+    return {
+      key: channel.key,
+      label: channel.label,
+      color: style.color,
+      width: style.width,
+      dash: style.dash,
+      format: (value) => `${value.toFixed(2)}${channel.unit}`,
+      points: result.samples.map((sample) => ({ time: sample.time_s, value: channel.extract(sample) })),
+    };
+  });
+
+  const overlaySeries: CanvasSeries[] = overlayRuns.flatMap((run) => {
+    const dash = overlayDashFor(run.manifest.run_id);
+    const tag = run.manifest.run_id.slice(5, 11);
+    return CHANNELS.map((channel) => {
+      const style = TRACE_STYLES[channel.key];
+      return {
+        key: `${channel.key}_${run.manifest.run_id}`,
+        label: `${channel.label} · ${tag}`,
+        color: style.color,
+        width: 1.4,
+        dash,
+        opacity: 0.7,
+        format: (value: number) => `${value.toFixed(2)}${channel.unit}`,
+        points: run.samples.map((sample) => ({ time: sample.time_s, value: channel.extract(sample) })),
+      };
+    });
+  });
 
   const markers = [
     ...(preInfusionEnd !== undefined
@@ -163,51 +79,14 @@ export function ChartStack({ result, comparisons, preInfusionEnd, onCursorChange
     })),
   ];
 
-  const charts: Record<ChartKey, { title: string; unit: string; series: Series[] }> = {
-    pressure: {
-      title: "Commanded pressure (bar)",
-      unit: "bar",
-      series: [
-        { key: "pressure_bar", label: "commanded pressure", color: palette[0] },
-        ...overlay("pressure_bar", "pressure"),
-      ],
-    },
-    flow: {
-      title: "Computed flow (ml/s)",
-      unit: "ml/s",
-      series: [
-        { key: "flow_ml_s", label: "flow", color: palette[0] },
-        ...overlay("flow_ml_s", "flow"),
-      ],
-    },
-    temperature: {
-      title: "Temperatures (°C)",
-      unit: "°C",
-      series: [
-        { key: "inlet_temperature_c", label: "inlet", color: palette[1], dashed: true },
-        { key: "puck_temperature_c", label: "puck", color: palette[0] },
-        ...overlay("puck_temperature_c", "puck"),
-      ],
-    },
-    mass: {
-      title: "Beverage mass (g)",
-      unit: "g",
-      series: [
-        { key: "beverage_mass_g", label: "beverage mass", color: palette[0] },
-        ...overlay("beverage_mass_g", "mass"),
-      ],
-    },
-    strength: {
-      title: "Strength and extraction (%)",
-      unit: "%",
-      series: [
-        { key: "tds_percent", label: "TDS", color: palette[1] },
-        { key: "extraction_yield_percent", label: "extraction yield", color: palette[0] },
-        ...overlay("extraction_yield_percent", "yield"),
-      ],
-    },
-  };
-  const selected = charts[selectedChart];
+  const ariaLabel =
+    `Shot analysis: ${CHANNELS.map((c) => c.label).join(", ")} over the shot's timeline` +
+    (overlayRuns.length > 0
+      ? `, overlaid with ${overlayRuns.length} pinned run${overlayRuns.length > 1 ? "s" : ""} (${overlayRuns
+          .map((run) => run.manifest.run_id.slice(5, 11))
+          .join(", ")})`
+      : "") +
+    (markers.length > 0 ? `, with ${markers.length} marked event${markers.length === 1 ? "" : "s"}.` : ".");
 
   return (
     <section className="analysis-surface" aria-labelledby="shot-analysis-title">
@@ -216,20 +95,22 @@ export function ChartStack({ result, comparisons, preInfusionEnd, onCursorChange
           <p className="eyebrow">Synchronized timeline</p>
           <h2 id="shot-analysis-title">Shot analysis</h2>
         </div>
-        <label htmlFor={selectorId}>
-          Signal
-          <select
-            id={selectorId}
-            value={selectedChart}
-            onChange={(event) => setSelectedChart(event.target.value as ChartKey)}
-          >
-            <option value="pressure">Commanded pressure</option>
-            <option value="flow">Computed flow</option>
-            <option value="temperature">Temperatures</option>
-            <option value="mass">Beverage mass</option>
-            <option value="strength">Strength and extraction</option>
-          </select>
-        </label>
+      </div>
+
+      <div className="analysis-legend" aria-hidden="true">
+        {CHANNELS.map((channel) => {
+          const style = TRACE_STYLES[channel.key];
+          return (
+            <span key={channel.key} className="analysis-legend-item">
+              <span
+                className="analysis-legend-swatch"
+                style={{ borderTopColor: style.color, borderTopStyle: style.dash ? "dashed" : "solid" }}
+              />
+              {channel.label}
+              {channel.unit}
+            </span>
+          );
+        })}
       </div>
 
       <div className="event-lane" aria-label="Shot timeline events">
@@ -240,10 +121,13 @@ export function ChartStack({ result, comparisons, preInfusionEnd, onCursorChange
         )) : <span>No warnings or stop events were recorded.</span>}
       </div>
 
-      <Chart
-        title={selected.title} unit={selected.unit} data={data} markers={markers}
+      <AnalysisCanvas
+        ariaLabel={ariaLabel}
+        series={[...series, ...overlaySeries]}
+        markers={markers}
+        preInfusionEnd={preInfusionEnd}
+        cursorTimeSeconds={cursorTimeSeconds}
         onCursorChange={onCursorChange}
-        series={selected.series}
       />
 
       <details className="analysis-data drawer">

--- a/web/src/features/shot/ControlRail.tsx
+++ b/web/src/features/shot/ControlRail.tsx
@@ -130,6 +130,7 @@ export function ControlRail(props: Props) {
 
   return (
     <aside className="rail">
+      <div className="rail-body">
       <div className="section">
         <h2>Recipe</h2>
         <select
@@ -233,7 +234,7 @@ export function ControlRail(props: Props) {
           range={inputRanges.pressure_bar}
           maxTimeSeconds={recipe.stop.maximum_time_s}
           unit="bar"
-          color="#d98b4a"
+          color="#f2ece2"
           onChange={(points) => onChange({ ...recipe, pressure_profile_bar: points })}
         />
       </div>
@@ -250,14 +251,21 @@ export function ControlRail(props: Props) {
         />
       </div>
 
-      <button onClick={props.onRun} disabled={props.running || issues.length > 0}>
-        {props.running ? "Simulating…" : "Run simulation"}
-      </button>
-      {issues.length > 0 && (
-        <p className="note" style={{ marginTop: 8 }}>
-          {issues.length} input{issues.length > 1 ? "s are" : " is"} outside the supported range.
-        </p>
-      )}
+      </div>
+
+      <div className="rail-footer">
+        <button onClick={props.onRun} disabled={props.running || issues.length > 0}>
+          {props.running ? "Simulating…" : "Run simulation"}
+        </button>
+        <div className="hint">
+          <span>⌘⏎</span>
+          <span>
+            {issues.length > 0
+              ? `${issues.length} input${issues.length > 1 ? "s are" : " is"} outside the supported range`
+              : "recipe ready to run"}
+          </span>
+        </div>
+      </div>
     </aside>
   );
 }

--- a/web/src/features/shot/NodeTable.tsx
+++ b/web/src/features/shot/NodeTable.tsx
@@ -1,0 +1,51 @@
+import type { ProfilePoint } from "../../api/types";
+
+interface Props {
+  points: ProfilePoint[];
+  range: readonly [number, number];
+  unit: string;
+  onUpdate: (index: number, position: 0 | 1, value: number) => void;
+  onAdd: () => void;
+  onChange: (points: ProfilePoint[]) => void;
+}
+
+// The always-visible numeric half of ProfileEditor (audit #08). Tabular
+// figures, one row per node, so a mistyped value is visible as a broken
+// column rather than hidden behind a toggle.
+export function NodeTable({ points, range, unit, onUpdate, onAdd, onChange }: Props) {
+  return (
+    <div className="node-table">
+      <div className="profile-row">
+        <span className="note" style={{ flex: 1 }}>time (s)</span>
+        <span className="note" style={{ flex: 1 }}>value</span>
+        <span style={{ width: 18 }} />
+      </div>
+      {points.map((point, index) => (
+        <div className="profile-row" key={index}>
+          <input
+            type="number" step={0.5} value={point[0]}
+            aria-label={`Point ${index + 1} time in seconds`}
+            onChange={(e) => onUpdate(index, 0, Number(e.target.value))}
+          />
+          <input
+            type="number" step={0.5} min={range[0]} max={range[1]} value={point[1]}
+            aria-label={`Point ${index + 1} value in ${unit}`}
+            onChange={(e) => onUpdate(index, 1, Number(e.target.value))}
+          />
+          <button
+            className="x"
+            title="remove point"
+            aria-label={`Remove point ${index + 1}`}
+            disabled={points.length <= 1}
+            onClick={() => onChange(points.filter((_, i) => i !== index))}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button className="ghost" aria-label="Add profile point" style={{ marginTop: 4, fontSize: 12 }} onClick={onAdd}>
+        Add point
+      </button>
+    </div>
+  );
+}

--- a/web/src/features/shot/ProfileCanvas.tsx
+++ b/web/src/features/shot/ProfileCanvas.tsx
@@ -29,6 +29,17 @@ export function ProfileCanvas({ points, range, maxTimeSeconds, unit, color, onCh
   const instructionsId = useId();
   const [dragIndex, setDragIndex] = useState<number>();
   const [hoverIndex, setHoverIndex] = useState<number>();
+  // Audit #08: the only readout used to be a 7.5px hover label that vanished
+  // on blur. selectedIndex is set by focus/drag/pointerdown and, unlike
+  // hoverIndex, is never cleared just because the pointer left the node -- so
+  // the readout below stays on screen once a point has been touched.
+  const [selectedIndex, setSelectedIndex] = useState<number | undefined>(points.length > 0 ? 0 : undefined);
+  const selected =
+    selectedIndex !== undefined && selectedIndex < points.length
+      ? selectedIndex
+      : points.length > 0
+        ? points.length - 1
+        : undefined;
 
   const span = maxTimeSeconds || 1;
   const [low, high] = range;
@@ -197,10 +208,10 @@ export function ProfileCanvas({ points, range, maxTimeSeconds, unit, color, onCh
             key={index}
             cx={toX(point[0])}
             cy={toY(point[1])}
-            r={dragIndex === index || hoverIndex === index ? 4.5 : 3.2}
+            r={dragIndex === index || hoverIndex === index || selected === index ? 4.5 : 3.2}
             fill={color}
-            stroke="var(--panel)"
-            strokeWidth={1.2}
+            stroke={selected === index ? "var(--text)" : "var(--panel)"}
+            strokeWidth={selected === index ? 2 : 1.2}
             style={{ cursor: "grab" }}
             role="slider"
             tabIndex={0}
@@ -213,6 +224,7 @@ export function ProfileCanvas({ points, range, maxTimeSeconds, unit, color, onCh
               event.stopPropagation();
               dragIndexRef.current = index;
               setDragIndex(index);
+              setSelectedIndex(index);
               try {
                 event.currentTarget.setPointerCapture(event.pointerId);
               } catch {
@@ -221,6 +233,7 @@ export function ProfileCanvas({ points, range, maxTimeSeconds, unit, color, onCh
             }}
             onPointerEnter={() => setHoverIndex(index)}
             onPointerLeave={() => setHoverIndex(undefined)}
+            onFocus={() => setSelectedIndex(index)}
             onKeyDown={(event) => handlePointKeyDown(event, index)}
             onDoubleClick={(event) => {
               event.stopPropagation();
@@ -229,15 +242,15 @@ export function ProfileCanvas({ points, range, maxTimeSeconds, unit, color, onCh
           />
         ))}
 
-        {hoverIndex !== undefined && points[hoverIndex] && (
+        {selected !== undefined && points[selected] && (
           <text
-            x={Math.min(toX(points[hoverIndex][0]) + 6, VIEW.width - 40)}
-            y={Math.max(toY(points[hoverIndex][1]) - 6, PAD.top + 8)}
-            fontSize={7.5}
+            x={Math.min(toX(points[selected][0]) + 6, VIEW.width - 40)}
+            y={Math.max(toY(points[selected][1]) - 6, PAD.top + 8)}
+            fontSize={8}
+            fontWeight={600}
             fill="var(--text)"
-            style={{ fontFamily: "ui-monospace, Menlo, monospace" }}
           >
-            {points[hoverIndex][0]}s · {points[hoverIndex][1]}
+            node {selected + 1} · {points[selected][0]}s · {points[selected][1]}
           </text>
         )}
       </svg>

--- a/web/src/features/shot/ProfileEditor.test.tsx
+++ b/web/src/features/shot/ProfileEditor.test.tsx
@@ -19,27 +19,19 @@ function renderEditor(points: ProfilePoint[] = POINTS) {
   return { onChange };
 }
 
-describe("ProfileEditor: numeric disclosure", () => {
-  it("hides the numeric point list until 'Edit numeric points' is toggled open", async () => {
-    const user = userEvent.setup();
+describe("ProfileEditor: numeric points are always visible (audit #08)", () => {
+  it("shows the numeric point list on mount, with no disclosure toggle to find first", () => {
     renderEditor();
-    const toggle = screen.getByRole("button", { name: /edit numeric points \(3\)/i });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByLabelText(/point 1 time in seconds/i)).not.toBeInTheDocument();
-
-    await user.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByRole("button", { name: /hide numeric points/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit numeric points/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /hide numeric points/i })).not.toBeInTheDocument();
     expect(screen.getByLabelText(/point 1 time in seconds/i)).toHaveValue(0);
     expect(screen.getByLabelText(/point 2 value in bar/i)).toHaveValue(2);
   });
 });
 
 describe("ProfileEditor: numeric editing", () => {
-  it("patches only the edited point's time, leaving the rest of the array untouched", async () => {
-    const user = userEvent.setup();
+  it("patches only the edited point's time, leaving the rest of the array untouched", () => {
     const { onChange } = renderEditor();
-    await user.click(screen.getByRole("button", { name: /edit numeric points/i }));
 
     fireEvent.change(screen.getByLabelText(/point 2 time in seconds/i), { target: { value: "7.5" } });
     expect(onChange).toHaveBeenCalledWith([
@@ -49,10 +41,8 @@ describe("ProfileEditor: numeric editing", () => {
     ]);
   });
 
-  it("patches only the edited point's value", async () => {
-    const user = userEvent.setup();
+  it("patches only the edited point's value", () => {
     const { onChange } = renderEditor();
-    await user.click(screen.getByRole("button", { name: /edit numeric points/i }));
 
     fireEvent.change(screen.getByLabelText(/point 3 value in bar/i), { target: { value: "8" } });
     expect(onChange).toHaveBeenCalledWith([
@@ -65,7 +55,6 @@ describe("ProfileEditor: numeric editing", () => {
   it("adds a point 5 seconds after the last one, at the last point's value", async () => {
     const user = userEvent.setup();
     const { onChange } = renderEditor();
-    await user.click(screen.getByRole("button", { name: /edit numeric points/i }));
     await user.click(screen.getByRole("button", { name: /add profile point/i }));
     expect(onChange).toHaveBeenCalledWith([...POINTS, [15, 9]]);
   });
@@ -73,7 +62,6 @@ describe("ProfileEditor: numeric editing", () => {
   it("adds the first point at t=0 for an empty profile", async () => {
     const user = userEvent.setup();
     const { onChange } = renderEditor([]);
-    await user.click(screen.getByRole("button", { name: /edit numeric points \(0\)/i }));
     await user.click(screen.getByRole("button", { name: /add profile point/i }));
     expect(onChange).toHaveBeenCalledWith([[0, 0]]);
   });
@@ -81,7 +69,6 @@ describe("ProfileEditor: numeric editing", () => {
   it("removes the targeted point by index", async () => {
     const user = userEvent.setup();
     const { onChange } = renderEditor();
-    await user.click(screen.getByRole("button", { name: /edit numeric points/i }));
     await user.click(screen.getByRole("button", { name: /remove point 2/i }));
     expect(onChange).toHaveBeenCalledWith([
       [0, 2],
@@ -89,10 +76,8 @@ describe("ProfileEditor: numeric editing", () => {
     ]);
   });
 
-  it("disables removal once only one point remains", async () => {
-    const user = userEvent.setup();
+  it("disables removal once only one point remains", () => {
     renderEditor([[0, 6]]);
-    await user.click(screen.getByRole("button", { name: /edit numeric points \(1\)/i }));
     expect(screen.getByRole("button", { name: /remove point 1/i })).toBeDisabled();
   });
 });

--- a/web/src/features/shot/ProfileEditor.tsx
+++ b/web/src/features/shot/ProfileEditor.tsx
@@ -1,6 +1,5 @@
-import { useId, useState } from "react";
-
 import type { ProfilePoint } from "../../api/types";
+import { NodeTable } from "./NodeTable";
 import { ProfileCanvas } from "./ProfileCanvas";
 
 interface Props {
@@ -12,12 +11,12 @@ interface Props {
   onChange: (points: ProfilePoint[]) => void;
 }
 
-// Section 12.3: a graphical control over the same points, with direct numeric
-// editing underneath. The numeric form is the one that survives a scope cut
-// (15.2), so it stays first-class rather than becoming a read-out.
+// Audit #08: the numeric point list used to default to hidden behind an 11px
+// ghost toggle, so the graph and the numbers were never visible together.
+// The node table is now always rendered beside/below the graph -- the one
+// view this system treats as authoritative on a scope cut (15.2) is now also
+// the one always on screen.
 export function ProfileEditor({ points, range, maxTimeSeconds, unit, color, onChange }: Props) {
-  const [showNumbers, setShowNumbers] = useState(false);
-  const numericPointsId = useId();
   const update = (index: number, position: 0 | 1, value: number) => {
     const next = points.map((point, i) =>
       i === index ? ((position === 0 ? [value, point[1]] : [point[0], value]) as ProfilePoint) : point,
@@ -31,7 +30,7 @@ export function ProfileEditor({ points, range, maxTimeSeconds, unit, color, onCh
   };
 
   return (
-    <div>
+    <div className="profile-editor">
       <ProfileCanvas
         points={points}
         range={range}
@@ -40,57 +39,7 @@ export function ProfileEditor({ points, range, maxTimeSeconds, unit, color, onCh
         color={color}
         onChange={onChange}
       />
-
-      <button
-        className="ghost"
-        style={{ marginTop: 6, fontSize: 11, padding: "4px 8px" }}
-        onClick={() => setShowNumbers((current) => !current)}
-        aria-expanded={showNumbers}
-        aria-controls={numericPointsId}
-      >
-        {showNumbers ? "Hide" : "Edit"} numeric points ({points.length})
-      </button>
-
-      {showNumbers && (
-        <div id={numericPointsId} style={{ marginTop: 8 }}>
-          <div className="profile-row">
-            <span className="note" style={{ flex: 1 }}>time (s)</span>
-            <span className="note" style={{ flex: 1 }}>value</span>
-            <span style={{ width: 18 }} />
-          </div>
-          {points.map((point, index) => (
-            <div className="profile-row" key={index}>
-              <input
-                type="number" step={0.5} value={point[0]}
-                aria-label={`Point ${index + 1} time in seconds`}
-                onChange={(e) => update(index, 0, Number(e.target.value))}
-              />
-              <input
-                type="number" step={0.5} min={range[0]} max={range[1]} value={point[1]}
-                aria-label={`Point ${index + 1} value in ${unit}`}
-                onChange={(e) => update(index, 1, Number(e.target.value))}
-              />
-              <button
-                className="x"
-                title="remove point"
-                aria-label={`Remove point ${index + 1}`}
-                disabled={points.length <= 1}
-                onClick={() => onChange(points.filter((_, i) => i !== index))}
-              >
-                ×
-              </button>
-            </div>
-          ))}
-          <button
-            className="ghost"
-            aria-label="Add profile point"
-            style={{ marginTop: 4, fontSize: 12 }}
-            onClick={add}
-          >
-            Add point
-          </button>
-        </div>
-      )}
+      <NodeTable points={points} range={range} unit={unit} onUpdate={update} onAdd={add} onChange={onChange} />
     </div>
   );
 }

--- a/web/src/features/shot/ShotWorkspace.tsx
+++ b/web/src/features/shot/ShotWorkspace.tsx
@@ -9,11 +9,10 @@ import { FlavorPanel } from "./FlavorPanel";
 import { MetricStrip } from "./MetricStrip";
 import { PuckView } from "./PuckView";
 
-// recharts (and the d3/decimal.js chain it pulls in) is the single largest
-// contributor to the production bundle -- see the bundle-visualizer note in
-// vite.config.ts. ChartStack only ever renders once a shot has run, so a
-// dynamic import keeps that weight out of the chunk needed just to open the
-// workbench and edit a recipe.
+// ChartStack now draws through AnalysisCanvas rather than recharts, so it no
+// longer carries that dependency's weight -- but it still only ever renders
+// once a shot has run, so a dynamic import keeps its own chunk out of what's
+// needed just to open the workbench and edit a recipe.
 const ChartStack = lazy(() => import("./ChartStack").then((mod) => ({ default: mod.ChartStack })));
 
 interface Props {
@@ -90,6 +89,7 @@ export function ShotWorkspace({
                 result={active}
                 comparisons={comparisons}
                 preInfusionEnd={activeRecipe ? preInfusionEnd(activeRecipe) : undefined}
+                cursorTimeSeconds={cursorTimeSeconds}
                 onCursorChange={setCursorTimeSeconds}
               />
             </Suspense>

--- a/web/src/features/sweeps/HeatMap.test.tsx
+++ b/web/src/features/sweeps/HeatMap.test.tsx
@@ -103,34 +103,85 @@ describe("HeatMap: invalid runs", () => {
   });
 });
 
-describe("HeatMap: hover and keyboard detail", () => {
-  it("shows the hovered cell's detail and clears it on mouse leave", async () => {
+describe("HeatMap: live preview vs. sticky pin (audit #09)", () => {
+  it("shows the hovered cell's detail as a live preview, falling back to the placeholder with nothing pinned", async () => {
     const user = userEvent.setup();
     renderHeatMap();
-    expect(screen.getByText(/hover or focus a cell for its run/i)).toBeInTheDocument();
+    expect(screen.getByText(/click or focus a cell for its run/i)).toBeInTheDocument();
 
     const cell = screen.getByRole("button", { name: /temperature_profile_c\.constant 88, puck\.particle_diameter_um 250/i });
     await user.hover(cell);
     expect(screen.getByText(/target mass reached/i)).toBeInTheDocument();
 
     await user.unhover(cell);
-    expect(screen.getByText(/hover or focus a cell for its run/i)).toBeInTheDocument();
+    expect(screen.getByText(/click or focus a cell for its run/i)).toBeInTheDocument();
   });
 
-  it("shows the same detail on keyboard focus, so Tab reaches every cell's data", () => {
+  it("keeps a clicked cell's detail on screen after blur, instead of resetting to the placeholder", async () => {
+    const user = userEvent.setup();
     renderHeatMap();
     const cell = screen.getByRole("button", { name: /temperature_profile_c\.constant 96, puck\.particle_diameter_um 350/i });
-    fireEvent.focus(cell);
+
+    await user.click(cell);
+    expect(cell).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText(/target mass reached/i)).toBeInTheDocument();
+    expect(screen.getByText(/pinned/i)).toBeInTheDocument();
 
     fireEvent.blur(cell);
-    expect(screen.getByText(/hover or focus a cell for its run/i)).toBeInTheDocument();
+    // Audit #09: this is the concrete fix -- blur used to erase the detail
+    // entirely; it now survives because the cell was pinned, not just hovered.
+    expect(screen.getByText(/target mass reached/i)).toBeInTheDocument();
+    expect(screen.queryByText(/click or focus a cell for its run/i)).not.toBeInTheDocument();
+  });
+
+  it("holds a second, shift-clicked cell alongside the pinned one for side-by-side comparison", async () => {
+    const user = userEvent.setup();
+    renderHeatMap();
+    const first = screen.getByRole("button", { name: /temperature_profile_c\.constant 88, puck\.particle_diameter_um 250/i });
+    const second = screen.getByRole("button", { name: /temperature_profile_c\.constant 96, puck\.particle_diameter_um 350/i });
+
+    await user.click(first);
+    fireEvent.click(second, { shiftKey: true });
+
+    expect(screen.getByText(/pinned/i)).toBeInTheDocument();
+    expect(screen.getByText(/held/i)).toBeInTheDocument();
+    // Both cells' detail are visible at once -- two "target mass reached"
+    // blocks (both fixture rows share that termination).
+    expect(screen.getAllByText(/target mass reached/i)).toHaveLength(2);
+  });
+
+  it("moves focus between adjacent cells with arrow keys", () => {
+    renderHeatMap();
+    const start = screen.getByRole("button", { name: /temperature_profile_c\.constant 88, puck\.particle_diameter_um 250/i });
+    start.focus();
+    fireEvent.keyDown(start, { key: "ArrowRight" });
+    const right = screen.getByRole("button", { name: /temperature_profile_c\.constant 88, puck\.particle_diameter_um 300/i });
+    expect(right).toHaveFocus();
   });
 
   it("carries the metric value and unit in every cell's aria-label as a non-color alternative", () => {
     renderHeatMap();
     const cell = screen.getByRole("button", { name: /temperature_profile_c\.constant 88, puck\.particle_diameter_um 250/i });
     expect(cell.getAttribute("aria-label")).toMatch(/shot time \d+\.\d s/);
+  });
+});
+
+describe("HeatMap: baseline coordinate (audit #05)", () => {
+  it("marks the aria-label of the cell matching the baseline recipe's values", () => {
+    renderHeatMap({ baselineY: 92, baselineX: 300 });
+    const baselineCell = screen.getByRole("button", { name: /temperature_profile_c\.constant 92, puck\.particle_diameter_um 300/i });
+    expect(baselineCell.getAttribute("aria-label")).toMatch(/baseline/i);
+
+    const otherCell = screen.getByRole("button", { name: /temperature_profile_c\.constant 88, puck\.particle_diameter_um 250/i });
+    expect(otherCell.getAttribute("aria-label")).not.toMatch(/baseline/i);
+  });
+
+  it("marks no cell as baseline when the coordinates are not given", () => {
+    renderHeatMap();
+    const group = screen.getByRole("group", { name: /heat map of/i });
+    for (const button of within(group).getAllByRole("button")) {
+      expect(button.getAttribute("aria-label")).not.toMatch(/baseline/i);
+    }
   });
 });
 

--- a/web/src/features/sweeps/HeatMap.tsx
+++ b/web/src/features/sweeps/HeatMap.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { Fragment, useRef, useState } from "react";
 
 import type { SweepRunRow } from "../../api/types";
 
@@ -14,6 +14,11 @@ interface Props {
   metricLabel: string;
   metricUnit: string;
   partial?: boolean;
+  /** The baseline recipe's current value for each axis, if that axis maps to
+   * a resolvable scalar (audit #05) -- marks which cell the sweep varied
+   * away from and lets the detail panel report a delta. */
+  baselineY?: number;
+  baselineX?: number;
 }
 
 // Sequential, one hue, light to dark - the color job for magnitude on a grid.
@@ -59,10 +64,22 @@ function rampColor(t: number): string {
 // judgement the model does not support (section 8.5). That stays true now that a
 // per-bean sensory overlay exists: the overlay is bean-relative and lives on the
 // shot view, and no sweep metric encodes a taste judgement.
+// Audit #09: a single `hovered` slot used to reset on blur, so the detail
+// panel fell back to a placeholder and two cells could never be compared
+// side by side. `preview` keeps the old live hover/focus scan; `pinned` is
+// set by clicking (or activating with Enter/Space, since these are real
+// buttons) and survives blur; shift-click sets a second `held` cell so two
+// runs can sit in the detail panel together.
 export function HeatMap({
   rows, xValues, yValues, xLabel, yLabel, metric, metricLabel, metricUnit, partial = false,
+  baselineY, baselineX,
 }: Props) {
-  const [hovered, setHovered] = useState<SweepRunRow>();
+  const [preview, setPreview] = useState<SweepRunRow>();
+  const [pinned, setPinned] = useState<SweepRunRow>();
+  const [held, setHeld] = useState<SweepRunRow>();
+  const cellRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const primary = preview ?? pinned;
 
   const byCoordinate = new Map<string, SweepRunRow>();
   for (const row of rows) byCoordinate.set(`${row.coordinates[0]}|${row.coordinates[1]}`, row);
@@ -87,7 +104,8 @@ export function HeatMap({
       aria-label={
         `Heat map of ${metricLabel} across ${xLabel} and ${yLabel}, ` +
         `ranging ${format(min)} to ${format(max)} ${metricUnit}. ` +
-        "Tab through cells for each run's detail."
+        "Tab or use arrow keys to move between cells; click or press Enter to pin one's detail, " +
+        "shift-click a second cell to hold it alongside for comparison."
       }
     >
       <div style={{ display: "flex", gap: 10 }}>
@@ -129,32 +147,63 @@ export function HeatMap({
                 >
                   {rowIndex % yStride === 0 ? formatTick(y) : ""}
                 </div>
-                {xValues.map((x) => {
+                {xValues.map((x, columnIndex) => {
                   const row = byCoordinate.get(`${y}|${x}`);
                   const invalid = !row || row.termination === "invalid_state";
                   const t = row ? (row[metric] - min) / span : 0;
+                  const isBaseline =
+                    baselineY !== undefined &&
+                    baselineX !== undefined &&
+                    Math.abs(y - baselineY) < 1e-6 &&
+                    Math.abs(x - baselineX) < 1e-6;
                   // A hover-only tooltip leaves color as the only carrier of
                   // the value and is unreachable from the keyboard. Each cell
                   // is a real button: focus/blur mirror the hover handlers so
                   // Tab reaches the same detail panel a mouse does, and the
                   // aria-label is the non-color alternative to the ramp.
-                  const label = !row
-                    ? `${yLabel} ${formatTick(y)}, ${xLabel} ${formatTick(x)}: ` +
-                      (partial ? "not run before cancellation" : "no run")
-                    : invalid
-                      ? `${yLabel} ${formatTick(y)}, ${xLabel} ${formatTick(x)}: outside the supported input range`
-                      : `${yLabel} ${formatTick(y)}, ${xLabel} ${formatTick(x)}: ` +
-                        `${metricLabel} ${format(row[metric])} ${metricUnit}, ${row.termination.replace(/_/g, " ")}`;
+                  const label =
+                    (!row
+                      ? `${yLabel} ${formatTick(y)}, ${xLabel} ${formatTick(x)}: ` +
+                        (partial ? "not run before cancellation" : "no run")
+                      : invalid
+                        ? `${yLabel} ${formatTick(y)}, ${xLabel} ${formatTick(x)}: outside the supported input range`
+                        : `${yLabel} ${formatTick(y)}, ${xLabel} ${formatTick(x)}: ` +
+                          `${metricLabel} ${format(row[metric])} ${metricUnit}, ${row.termination.replace(/_/g, " ")}`) +
+                    (isBaseline ? " · baseline" : "");
+                  const cellKey = `${rowIndex}-${columnIndex}`;
                   return (
                     <button
                       key={`${y}-${x}`}
+                      ref={(el) => {
+                        if (el) cellRefs.current.set(cellKey, el);
+                        else cellRefs.current.delete(cellKey);
+                      }}
                       type="button"
                       disabled={!row}
                       aria-label={label}
-                      onMouseEnter={() => setHovered(row)}
-                      onMouseLeave={() => setHovered(undefined)}
-                      onFocus={() => setHovered(row)}
-                      onBlur={() => setHovered(undefined)}
+                      aria-pressed={pinned?.index === row?.index}
+                      onMouseEnter={() => setPreview(row)}
+                      onMouseLeave={() => setPreview(undefined)}
+                      onFocus={() => setPreview(row)}
+                      onBlur={() => setPreview(undefined)}
+                      onClick={(event) => {
+                        if (!row) return;
+                        if (event.shiftKey) {
+                          setHeld((current) => (current?.index === row.index ? undefined : row));
+                        } else {
+                          setPinned(row);
+                        }
+                      }}
+                      onKeyDown={(event) => {
+                        const deltas: Record<string, [number, number]> = {
+                          ArrowUp: [-1, 0], ArrowDown: [1, 0], ArrowLeft: [0, -1], ArrowRight: [0, 1],
+                        };
+                        const delta = deltas[event.key];
+                        if (!delta) return;
+                        event.preventDefault();
+                        const target = cellRefs.current.get(`${rowIndex + delta[0]}-${columnIndex + delta[1]}`);
+                        target?.focus();
+                      }}
                       style={{
                         height: cellHeight,
                         borderRadius: 2,
@@ -169,10 +218,13 @@ export function HeatMap({
                            ? "repeating-linear-gradient(45deg, #2b2320 0 4px, #1e1917 4px 8px)"
                           : rampColor(t),
                         outline:
-                          hovered && row && hovered.index === row.index
+                          row && (primary?.index === row.index || pinned?.index === row.index)
                             ? "2px solid var(--text)"
-                            : "none",
+                            : row && held?.index === row.index
+                              ? "2px dashed var(--accent)"
+                              : "none",
                         outlineOffset: -2,
+                        boxShadow: isBaseline ? "inset 0 0 0 1px var(--text)" : undefined,
                       }}
                     />
                   );
@@ -250,28 +302,50 @@ export function HeatMap({
         )}
       </div>
 
-      {/* Per-cell hover rather than a number in every cell: mid-ramp steps
-          cannot carry legible text against either ink. */}
-      <div className="tooltip" style={{ marginTop: 10, minHeight: 68 }}>
-        {hovered ? (
-          <>
-            <div className="t">
-              {yLabel} = {hovered.coordinates[0]} · {xLabel} = {hovered.coordinates[1]}
-            </div>
-            <div>
-              {hovered.shot_time_s.toFixed(2)} s · {hovered.beverage_mass_g.toFixed(1)} g ·{" "}
-              {hovered.tds_percent.toFixed(2)} % TDS ·{" "}
-              {hovered.extraction_yield_percent.toFixed(2)} % yield
-            </div>
-            <div style={{ color: "var(--muted)" }}>
-              {hovered.termination.replace(/_/g, " ")}
-              {hovered.warning_count > 0 && ` · ${hovered.warning_count} warning(s)`}
-            </div>
-          </>
-        ) : (
-          <div className="t">Hover or focus a cell for its run.</div>
+      {/* Audit #09: this used to be a single hover-only slot that reset on
+          blur. `primary` (live preview, falling back to the pinned cell) and
+          `held` (a second, shift-clicked cell) can now sit side by side. */}
+      <div className="row" style={{ marginTop: 10, gap: 2, alignItems: "stretch" }}>
+        <div className="tooltip" style={{ flex: 1, minHeight: 68 }}>
+          {primary ? (
+            <RunDetail row={primary} yLabel={yLabel} xLabel={xLabel} kicker={pinned && primary.index === pinned.index ? "pinned" : undefined} />
+          ) : (
+            <div className="t">Click or focus a cell for its run. Shift-click a second to hold it alongside.</div>
+          )}
+        </div>
+        {held && (
+          <div className="tooltip" style={{ flex: 1, minHeight: 68 }}>
+            <RunDetail row={held} yLabel={yLabel} xLabel={xLabel} kicker="held" />
+          </div>
         )}
       </div>
     </div>
+  );
+}
+
+function RunDetail({
+  row, yLabel, xLabel, kicker,
+}: {
+  row: SweepRunRow;
+  yLabel: string;
+  xLabel: string;
+  kicker?: string;
+}) {
+  return (
+    <>
+      <div className="t">
+        {yLabel} = {row.coordinates[0]} · {xLabel} = {row.coordinates[1]}
+        {kicker && <span style={{ marginLeft: 8, color: "var(--accent)", textTransform: "uppercase", fontSize: 10, letterSpacing: "0.08em" }}>{kicker}</span>}
+      </div>
+      <div>
+        {row.shot_time_s.toFixed(2)} s · {row.beverage_mass_g.toFixed(1)} g ·{" "}
+        {row.tds_percent.toFixed(2)} % TDS ·{" "}
+        {row.extraction_yield_percent.toFixed(2)} % yield
+      </div>
+      <div style={{ color: "var(--muted)" }}>
+        {row.termination.replace(/_/g, " ")}
+        {row.warning_count > 0 && ` · ${row.warning_count} warning(s)`}
+      </div>
+    </>
   );
 }

--- a/web/src/features/sweeps/SweepPanel.tsx
+++ b/web/src/features/sweeps/SweepPanel.tsx
@@ -33,6 +33,46 @@ function linspace({ from, to, steps }: AxisDraft): number[] {
   );
 }
 
+// Audit #05: axis drafts were hard-coded to 250-450µm/9 steps and 88-96°C/5
+// steps regardless of the baseline recipe, so a sweep could never express
+// "vary around here". Reads the swept parameter's current value off the
+// baseline recipe and centers a reasonable span on it instead.
+function scalarValueAt(recipe: Recipe, parameterPath: string): number | undefined {
+  switch (parameterPath) {
+    case "puck.particle_diameter_um":
+      return recipe.puck.particle_diameter_um ?? undefined;
+    case "puck.dose_g":
+      return recipe.puck.dose_g;
+    case "puck.basket_diameter_mm":
+      return recipe.puck.basket_diameter_mm;
+    case "puck.depth_mm":
+      return recipe.puck.depth_mm;
+    case "temperature_profile_c.constant":
+      return recipe.temperature_profile_c[0]?.[1];
+    default:
+      return undefined;
+  }
+}
+
+const AXIS_SPAN: Record<string, { width: number; steps: number }> = {
+  "puck.particle_diameter_um": { width: 200, steps: 9 },
+  "temperature_profile_c.constant": { width: 8, steps: 5 },
+  "puck.dose_g": { width: 4, steps: 5 },
+  "puck.basket_diameter_mm": { width: 10, steps: 5 },
+  "puck.depth_mm": { width: 10, steps: 5 },
+};
+
+function seedAxis(parameterPath: string, baseline: Recipe): AxisDraft {
+  const spec = AXIS_SPAN[parameterPath] ?? { width: 100, steps: 9 };
+  const center = scalarValueAt(baseline, parameterPath) ?? 0;
+  return {
+    parameterPath,
+    from: Number((center - spec.width / 2).toFixed(4)),
+    to: Number((center + spec.width / 2).toFixed(4)),
+    steps: spec.steps,
+  };
+}
+
 const METRICS: { key: HeatMetric; label: string; unit: string }[] = [
   { key: "shot_time_s", label: "shot time", unit: "s" },
   { key: "extraction_yield_percent", label: "extraction yield", unit: "%" },
@@ -91,12 +131,16 @@ function AxisControls({
 // heat map (section 11.1). Sweeps run synchronously in this build (15.2), so
 // "progress" is a busy state.
 export function SweepPanel({ baseline, parameters, onError }: Props) {
-  const [primary, setPrimary] = useState<AxisDraft>({
-    parameterPath: "puck.particle_diameter_um", from: 250, to: 450, steps: 9,
-  });
-  const [secondary, setSecondary] = useState<AxisDraft>({
-    parameterPath: "temperature_profile_c.constant", from: 88, to: 96, steps: 5,
-  });
+  // Lazy initializers: the drafts are seeded once from the baseline recipe
+  // present at mount, then edited freely -- the same "starting point, not a
+  // leash" contract the old hardcoded defaults had, just anchored to the
+  // actual recipe instead of an arbitrary constant.
+  const [primary, setPrimary] = useState<AxisDraft>(() =>
+    seedAxis("puck.particle_diameter_um", baseline),
+  );
+  const [secondary, setSecondary] = useState<AxisDraft>(() =>
+    seedAxis("temperature_profile_c.constant", baseline),
+  );
   const [twoDimensional, setTwoDimensional] = useState(false);
   const [metric, setMetric] = useState<HeatMetric>("shot_time_s");
   const [result, setResult] = useState<SweepResult>();
@@ -278,6 +322,8 @@ export function SweepPanel({ baseline, parameters, onError }: Props) {
               metricLabel={selected.label}
               metricUnit={selected.unit}
               partial={result.cancelled === true}
+              baselineY={scalarValueAt(baseline, result.axes![0].parameter_path)}
+              baselineX={scalarValueAt(baseline, result.axes![1].parameter_path)}
             />
           ) : (
             <div

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,14 +1,26 @@
 :root {
-  --bg: #110e0c;
-  --bg-raised: #171311;
-  --panel: #1e1917;
-  --panel-2: #29211c;
-  --line: #40342d;
-  --line-strong: #5a4639;
-  --text: #f4ece4;
-  --muted: #ad9d92;
-  --accent: #e69a59;
-  --accent-strong: #f2b273;
+  /* Laboratory-notebook dark theme (design canvas project e14ffbff,
+     "EspressoLab Hi-Fi" + "Audit and Handoff"). --panel/--bg-raised/--panel-2
+     are kept as the existing surface names other components already
+     reference; their values are retargeted to the new warm-black ramp
+     rather than renamed everywhere in one pass. */
+  --bg: #0b0a09;           /* canvas, outside the app frame */
+  --bg-well: #0d0b09;      /* recessed chart plot well */
+  --bg-raised: #17140f;    /* frame: app body, header, tab bar, metric bar */
+  --panel: #1d1914;        /* rail: side panels, cards */
+  --panel-2: #241d13;      /* row hover / lifted tooltip surface */
+  --bg-footer: #191510;    /* non-scrolling action footer */
+  --bg-readout: #151210;   /* cursor tooltip, floating over the well */
+  --line: #302a22;         /* structural rule */
+  --line-row: #262019;     /* row rule */
+  --line-strong: #453d31;  /* control border */
+  --text: #f2ece2;
+  --muted: #a99e8d;
+  --text-dim: #776d5f;     /* tertiary text, kickers */
+  --accent: #d5a25a;       /* gold. Restricted to: the primary-action outline,
+                               the active/editable rail value, the flow/
+                               simulated trace, and the playback cursor. */
+  --accent-strong: #e9bd7c;
   --accent-2: #6fb3c8;
   --warn: #e0a03a;
   --bad: #d9584a;
@@ -17,7 +29,9 @@
   --radius-md: 9px;
   --radius-lg: 14px;
   --shadow-panel: 0 18px 50px rgba(0, 0, 0, 0.18);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-heading: "Cormorant Garamond", Georgia, serif;
+  --font-body: "Lora", Georgia, serif;
+  font-family: var(--font-body);
   color-scheme: dark;
 }
 
@@ -25,13 +39,17 @@
 
 body {
   margin: 0;
-  background:
-    radial-gradient(circle at 78% -10%, rgba(111, 179, 200, 0.08), transparent 30rem),
-    radial-gradient(circle at 10% 0%, rgba(230, 154, 89, 0.07), transparent 26rem),
-    var(--bg);
+  background: var(--bg);
   color: var(--text);
+  font-family: var(--font-body);
   font-size: 14px;
   line-height: 1.45;
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--font-heading);
+  font-weight: 400; /* the bigger the text, the lighter it sets -- bold is
+                        reserved for kickers/labels, never display type */
 }
 
 .app {
@@ -87,14 +105,36 @@ body {
 .workflow-tab[aria-selected="true"]::after { background: var(--accent); }
 .workflow-tab:hover { color: var(--text); background: rgba(255, 255, 255, 0.025); }
 
+/* Audit #01: the primary action used to sit at the bottom of a scrolling
+   config column and could go below the fold. The rail is now a flex column
+   with its own scroll region (.rail-body) and a non-scrolling action footer
+   that always holds the Run button. */
 .rail {
   height: 100%;
   background: var(--panel);
-  padding: 18px;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-panel);
+}
+.rail-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 18px; }
+.rail-footer {
+  flex: 0 0 auto;
+  padding: 16px 18px;
+  border-top: 1px solid var(--line);
+  background: var(--bg-footer);
+}
+.rail-footer button { width: 100%; }
+.rail-footer .hint {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
 }
 
 .main {
@@ -154,7 +194,8 @@ body {
   color: var(--text);
   padding: 5px 7px;
   border-radius: 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-body);
+  font-variant-numeric: tabular-nums;
   font-size: 12px;
   text-align: right;
 }
@@ -171,37 +212,77 @@ select {
   font-size: 13px;
 }
 
+/* No button is ever filled -- Classical primitive: three weights told apart
+   by border color/weight and ink alone (primary gold / secondary control-
+   border / tertiary row-rule). */
 button, .button {
-  background: var(--accent);
-  border: none;
-  color: #1b1310;
-  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent-strong);
+  padding: 9px 16px;
   border-radius: var(--radius-sm);
+  font-family: var(--font-body);
   font-weight: 600;
-  font-size: 13px;
+  font-size: 12.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
   display: inline-block;
   text-decoration: none;
 }
-button:disabled { background: var(--line); color: var(--muted); cursor: not-allowed; }
-button.ghost, .button.ghost { background: transparent; border: 1px solid var(--line); color: var(--text); font-weight: 500; }
-button:hover:not(:disabled), .button:hover { filter: brightness(1.08); }
+button:disabled { border-color: var(--line); color: var(--muted); cursor: not-allowed; }
+button.ghost, .button.ghost {
+  border-color: var(--line-strong);
+  color: var(--text);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: normal;
+}
+button.tertiary, .button.tertiary {
+  border-color: var(--line);
+  color: var(--text-dim);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: normal;
+}
+button:hover:not(:disabled), .button:hover { background: color-mix(in srgb, var(--accent) 10%, transparent); }
+button.ghost:hover:not(:disabled), .button.ghost:hover,
+button.tertiary:hover:not(:disabled), .button.tertiary:hover { background: rgba(255, 255, 255, 0.03); }
 :where(button, .button, a, input, select, summary):focus-visible {
   outline: 2px solid var(--accent-2);
   outline-offset: 3px;
 }
 
-.metric-strip { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 16px; }
-.metric {
-  background: var(--panel);
-  border: 1px solid var(--line);
+/* Audit #02: results used to render after a full screen of inputs. The
+   metric bar is the display-metric primitive (kicker -> Cormorant figure ->
+   caption) and is always the first thing shown once a run has landed. */
+.metric-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  background: var(--line-row);
+  border: 1px solid var(--line-row);
   border-radius: var(--radius-md);
-  padding: 9px 13px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+.metric {
+  flex: 1 1 130px;
+  background: var(--bg-raised);
+  border: none;
+  border-radius: 0;
+  padding: 14px 16px;
   min-width: 108px;
 }
-.metric .label { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.07em; }
-.metric .value { font-size: 19px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; margin-top: 2px; }
-.metric .unit { font-size: 11px; color: var(--muted); margin-left: 3px; }
+.metric .label { color: var(--text-dim); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.16em; }
+.metric .value {
+  font-family: var(--font-heading);
+  font-weight: 400;
+  font-size: 27px;
+  font-variant-numeric: tabular-nums;
+  margin-top: 6px;
+}
+.metric .unit { font-family: var(--font-body); font-size: 13px; color: var(--muted); margin-left: 4px; }
 
 .chart-card {
   background: var(--panel);
@@ -209,6 +290,9 @@ button:hover:not(:disabled), .button:hover { filter: brightness(1.08); }
   border-radius: var(--radius-md);
   padding: 13px 14px 6px;
   margin-bottom: 14px;
+  /* Audit #10: reserve the chart's settled height so mounting a result does
+     not reflow controls the user may be reaching for. */
+  min-height: 300px;
 }
 .chart-card h3 { margin: 0 0 6px; font-size: 12px; color: var(--muted); font-weight: 600; }
 .analysis-surface { margin: 22px 0; }
@@ -217,10 +301,65 @@ button:hover:not(:disabled), .button:hover { filter: brightness(1.08); }
 .analysis-heading label { display: grid; gap: 5px; min-width: 220px; color: var(--muted); font-size: 11px; }
 .event-lane { display: flex; gap: 7px; overflow-x: auto; padding: 8px 0 12px; color: var(--muted); font-size: 11px; }
 .event-lane span { flex: 0 0 auto; padding: 5px 8px; border-left: 2px solid var(--line-strong); background: var(--bg-raised); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
-.event-lane b { color: var(--text); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 550; }
+.event-lane b { color: var(--text); font-family: var(--font-body); font-variant-numeric: tabular-nums; font-weight: 550; }
 .analysis-data { margin-top: 10px; }
 .analysis-data .table-scroll { max-height: 360px; overflow: auto; padding: 0 12px 12px; }
 .analysis-data th { position: sticky; top: 0; background: var(--panel); }
+
+/* AnalysisCanvas: the unified multi-trace well that replaced per-signal
+   recharts LineCharts (audit #03/#04). */
+.analysis-canvas { padding-bottom: 12px; }
+.analysis-canvas-well {
+  position: relative;
+  background: var(--bg-well);
+  border: 1px solid var(--line-row);
+  border-radius: var(--radius-sm);
+}
+.analysis-canvas-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+.analysis-gridline { stroke: var(--bg-raised); stroke-width: 1; }
+.analysis-preinfusion { fill: var(--accent); opacity: 0.05; }
+.analysis-preinfusion-divider { stroke: var(--line-strong); stroke-dasharray: 3 4; stroke-width: 1; }
+.analysis-zero-rule { stroke: var(--line-row); stroke-width: 1; }
+.analysis-cursor { stroke: var(--accent); stroke-width: 1; }
+.analysis-residual-label {
+  position: absolute;
+  left: 12px;
+  transform: translateY(6px);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.analysis-legend { display: flex; flex-wrap: wrap; gap: 18px; margin-bottom: 10px; font-size: 11px; color: var(--muted); letter-spacing: 0.02em; }
+.analysis-legend-item { display: flex; align-items: center; gap: 8px; }
+.analysis-legend-swatch { display: block; width: 22px; height: 0; border-top-width: 2px; border-top-style: solid; }
+
+.cursor-readout {
+  position: absolute;
+  top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 11px 13px;
+  background: var(--bg-readout);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.cursor-readout-time {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.cursor-readout-rule { height: 1px; background: var(--line-row); }
+.cursor-readout-row { display: flex; gap: 16px; justify-content: space-between; }
+.cursor-readout-label { color: var(--text-dim); }
 
 .tooltip {
   background: var(--panel-2);
@@ -228,7 +367,8 @@ button:hover:not(:disabled), .button:hover { filter: brightness(1.08); }
   border-radius: 4px;
   padding: 7px 9px;
   font-size: 12px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-body);
+  font-variant-numeric: tabular-nums;
 }
 .tooltip .t { color: var(--muted); margin-bottom: 4px; }
 
@@ -236,7 +376,7 @@ button:hover:not(:disabled), .button:hover { filter: brightness(1.08); }
 .drawer summary { padding: 10px 12px; cursor: pointer; font-size: 12px; color: var(--muted); font-weight: 600; }
 .drawer .body { padding: 0 12px 12px; }
 
-table { width: 100%; border-collapse: collapse; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+table { width: 100%; border-collapse: collapse; font-size: 12px; font-family: var(--font-body); font-variant-numeric: tabular-nums; }
 th, td { text-align: right; padding: 4px 8px; border-bottom: 1px solid var(--line); }
 th:first-child, td:first-child { text-align: left; }
 th { color: var(--muted); font-weight: 600; }
@@ -249,13 +389,15 @@ tbody tr[tabindex], tbody tr[role="button"] { cursor: pointer; }
 .warning.info { background: rgba(111, 179, 200, 0.1); border-left: 3px solid var(--accent-2); }
 .warning code { color: var(--muted); }
 
-.kv { display: grid; grid-template-columns: auto 1fr; gap: 3px 14px; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.kv { display: grid; grid-template-columns: auto 1fr; gap: 3px 14px; font-size: 12px; font-family: var(--font-body); font-variant-numeric: tabular-nums; }
 .kv .k { color: var(--muted); }
 
 .note { color: var(--muted); font-size: 11px; line-height: 1.5; }
 .error { background: rgba(217, 88, 74, 0.14); border-left: 3px solid var(--bad); padding: 9px 11px; border-radius: 4px; margin-bottom: 12px; font-size: 12px; }
+.profile-editor { display: flex; flex-direction: column; gap: 6px; }
+.node-table { margin-top: 6px; }
 .profile-row { display: flex; gap: 6px; margin-bottom: 5px; align-items: center; }
-.profile-row input { width: 100%; background: var(--bg); border: 1px solid var(--line); color: var(--text); padding: 4px 6px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; text-align: right; }
+.profile-row input { width: 100%; background: var(--bg); border: 1px solid var(--line); color: var(--text); padding: 4px 6px; border-radius: 4px; font-family: var(--font-body); font-variant-numeric: tabular-nums; font-size: 12px; text-align: right; }
 .profile-row .x { background: none; border: none; color: var(--muted); cursor: pointer; padding: 0 4px; font-size: 14px; }
 .row { display: flex; gap: 8px; align-items: center; }
 .toggle-field { display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; margin-bottom: 8px; }
@@ -273,7 +415,8 @@ tbody tr[tabindex], tbody tr[role="button"] { cursor: pointer; }
 .puck-clock {
   color: var(--muted);
   font-size: 11px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-body);
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
@@ -317,6 +460,30 @@ tbody tr[tabindex], tbody tr[role="button"] { cursor: pointer; }
 .reference-card .kv { padding-top: 3px; font-size: 11px; }
 .reference-load-errors { color: var(--warn); border-top: 1px solid var(--line); margin-top: 12px; padding-top: 9px; font-size: 11px; line-height: 1.5; }
 
+/* Audit #06: one ground-truth list mixing measured shots and published
+   references, replacing the separate Measured data / References tabs. */
+.calibration { display: flex; flex-direction: column; gap: 14px; }
+.ground-truth-list { display: flex; flex-direction: column; gap: 1px; background: var(--line-row); border: 1px solid var(--line-row); border-radius: var(--radius-md); overflow: hidden; }
+.ground-truth-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  align-items: flex-start;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: none;
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+  color: var(--muted);
+}
+.ground-truth-row .ground-truth-name { font-family: var(--font-body); font-size: 13px; color: var(--text); }
+.ground-truth-row .ground-truth-caption { font-size: 10.5px; color: var(--text-dim); }
+.ground-truth-row.selected { border-left-color: var(--accent); background: var(--panel-2); }
+.ground-truth-row.selected .ground-truth-name { color: var(--text); }
+
 .measured-comparison { overflow: hidden; }
 .measured-comparison-heading { display: flex; justify-content: space-between; align-items: flex-start; gap: 14px; }
 .measured-comparison-heading h3 { margin-bottom: 3px; }
@@ -326,7 +493,8 @@ tbody tr[tabindex], tbody tr[role="button"] { cursor: pointer; }
   border: 1px solid rgba(111, 179, 200, 0.45);
   border-radius: 999px;
   padding: 3px 8px;
-  font: 10px ui-monospace, SFMono-Regular, Menlo, monospace;
+  font: 10px var(--font-body);
+  font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
   white-space: nowrap;
 }
@@ -420,7 +588,7 @@ tbody tr[tabindex], tbody tr[role="button"] { cursor: pointer; }
    estimates and should not out-shout the measured metric strip. */
 .flavor-heuristic { color: var(--muted); font-weight: 400; margin-left: 6px; text-transform: none; }
 .flavor-headline { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 10px; }
-.flavor-score { font-size: 22px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.flavor-score { font-size: 22px; font-family: var(--font-body); font-variant-numeric: tabular-nums; }
 .flavor-headline .unit { font-size: 11px; color: var(--muted); margin-left: 4px; }
 .flavor-verdict { font-size: 12px; color: var(--accent-2); }
 .flavor-dominant { font-size: 11px; color: var(--muted); }
@@ -430,7 +598,7 @@ tbody tr[tabindex], tbody tr[role="button"] { cursor: pointer; }
 .flavor-track { position: relative; height: 10px; background: var(--panel-2); border-radius: 5px; }
 .flavor-fill { height: 100%; background: var(--accent); border-radius: 5px; }
 .flavor-target { position: absolute; top: -2px; width: 2px; height: 14px; background: var(--fg, #e8ded6); opacity: 0.75; }
-.flavor-axis-value { font-size: 11px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.flavor-axis-value { font-size: 11px; font-family: var(--font-body); font-variant-numeric: tabular-nums; }
 .flavor-axis-dev { color: var(--muted); margin-left: 6px; }
 .flavor-composition { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
 .flavor-chip { font-size: 10px; color: var(--muted); background: var(--panel-2); border: 1px solid var(--line); border-radius: 3px; padding: 2px 6px; }

--- a/web/src/theme/traceStyles.ts
+++ b/web/src/theme/traceStyles.ts
@@ -1,0 +1,46 @@
+// Single source for chart trace color/weight/dash, replacing the four
+// independent hardcoded-hex palettes that used to live in ChartStack.tsx,
+// HeatMap.tsx, SweepPanel.tsx, and MeasuredShotComparison.tsx (audit "Tokens
+// and primitives" sheet + design canvas project e14ffbff). Gold is load-
+// bearing and restricted to exactly four uses across the app; the flow trace
+// here and the "simulated" trace in Calibration share it deliberately.
+
+export interface TraceStyle {
+  color: string;
+  width: number;
+  dash?: string;
+}
+
+export type TraceKey =
+  | "pressure"
+  | "measured"
+  | "flow"
+  | "simulated"
+  | "mass"
+  | "temperature"
+  | "residual";
+
+export const TRACE_STYLES: Record<TraceKey, TraceStyle> = {
+  pressure: { color: "#f2ece2", width: 2.2 },
+  measured: { color: "#f2ece2", width: 2.2 },
+  flow: { color: "#d5a25a", width: 2.2, dash: "6 5" },
+  simulated: { color: "#d5a25a", width: 2.2, dash: "6 5" },
+  mass: { color: "#8f8474", width: 1.6, dash: "5 4" },
+  temperature: { color: "#6b6255", width: 1.6, dash: "2 4" },
+  residual: { color: "#8a6226", width: 1.5 },
+};
+
+// Audit #07: ChartStack.overlay() used to assign palette[index + 1] by
+// position in the comparisons array, so unpinning one run silently recolored
+// every remaining run. Pinned/overlay runs now keep the same base channel
+// color and are told apart by a dash pattern keyed to the run's own id, which
+// stays stable regardless of how many other runs are pinned or in what order.
+const OVERLAY_DASHES = ["3 3", "7 3 1 3", "1 3", "8 2 2 2", "2 2 6 2"];
+
+export function overlayDashFor(runId: string): string {
+  let hash = 0;
+  for (let index = 0; index < runId.length; index += 1) {
+    hash = (hash * 31 + runId.charCodeAt(index)) >>> 0;
+  }
+  return OVERLAY_DASHES[hash % OVERLAY_DASHES.length];
+}


### PR DESCRIPTION
## Summary

Lands a substantial piece of previously-uncommitted work that had been
sitting in the worktree, split into logical commits:

1. **`fix(cfd3d)`**: `make_sample()` weighted the reported puck temperature
   by *pore* capacity (the same quantity used for saturation) instead of
   *thermal* capacity, and the per-node ambient heat-loss power wasn't
   divided by `mesh.nz`, over-counting loss by a factor of `nz` for any
   mesh with more than one axial layer. Both fixed, with new regression
   coverage in `tests/integration/test_cfd3d.cpp`. Reconciled with
   `perf(cfd3d): cache water properties per timestep` (already on `main`)
   so the fix reads from the per-timestep water-property cache rather than
   recomputing it.
2. **`feat(web)`**: a systematic dashboard UX audit (comments reference
   "Audit #04" through "Audit #09"):
   - `ChartStack` now draws through a new hand-rolled `AnalysisCanvas`/
     `CursorReadout` instead of recharts (recharts remains in
     `MeasuredShotComparison` and `SweepPanel`).
   - The separate "Measured data" and "References" tabs merge into one
     "Calibration" tab backed by a shared `GroundTruthList`.
   - `HeatMap` gains pin/hold-compare (click to pin past blur, shift-click
     to hold a second cell for side-by-side comparison).
   - The profile editor's numeric points are on screen by default.

   Reconciled with `perf(web): code-split recharts behind lazy chart
   panels` (already on `main`): `App.tsx` now lazy-loads the consolidated
   `<Calibration>` behind the same `visitedWorkflows`/`Suspense`
   scaffolding that used to wrap the separate Measured-data panel.
3. **`chore(claude)`**: two new subagents (`scout`, `verifier`) and two
   workflow skills (`perf-branch-workflow`, `repo-orchestrator`).
4. **`docs(specs)`**: three design-spec docs from recent sessions.
5. **`chore`**: `.gitignore` entries for local scratch/tooling directories
   that had been sitting untracked (`CoffeeSim/`, `profiling/`, `results/`,
   `.opencode/`, session/log dumps, `__pycache__/`).

Neither the CFD3D fix nor the dashboard changes have been validated
against a real measured shot — standing project disclosure, not new to
this change (see `docs/current-state-and-gaps.md`).

## Verification

- Full Catch2 suite: 229 cases / 86,970 assertions
- `[cfd3d]` tag specifically: 14 cases / 853 assertions
- `scripts/demo.sh`: default-pipeline result hash unchanged
  (`80156b2e...`), confirming CFD3D stayed outside the default pipeline
- `npm run typecheck`: clean
- `npm run test:coverage`: 229/229 (18 files), 97.44% statement coverage
- `npm run build`: no bundle-size warning; lazy chunks (`ChartStack`,
  `Calibration`, `SweepPanel`) split as expected
- `npm run test:e2e`: 26/26 (Chromium desktop + mobile) against the
  native server

🤖 Generated with [Claude Code](https://claude.com/claude-code)