### PR TITLE
Remove lazy loading from ChartStack to fix Suspense starvation

### DIFF
--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -41,6 +41,29 @@ test("edits a recipe and runs a simulation, showing metrics and diagnostics", as
   await expect(page.getByText(/run id/)).toBeVisible();
 });
 
+test("the shot analysis chart appears while the puck transport is still playing", async ({ page }) => {
+  // Regression: ChartStack used to be a lazy import behind a Suspense
+  // boundary that sat beside PuckView. A completed run auto-plays PuckView's
+  // transport, which sets state from requestAnimationFrame on every frame for
+  // the length of the shot; those default-priority updates starved React's
+  // retry of the suspended boundary, so the charts stayed behind
+  // "Loading charts..." until playback ended (29 s on the baseline recipe) or
+  // the reader hit Pause. The assertions below all run while the transport is
+  // still playing, which is what made the old code fail.
+  await page.goto("/");
+  await openRecipeEditor(page);
+  await page.getByRole("button", { name: "Run simulation" }).click();
+  await expect(page.locator(".metric-strip")).toBeVisible({ timeout: 15000 });
+
+  // "Pause" is the transport's label only while it is playing.
+  await expect(page.getByRole("button", { name: "Pause" })).toBeVisible();
+  await expect(page.locator(".analysis-canvas-well")).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText("Loading charts...")).toHaveCount(0);
+  await expect(page.locator(".analysis-canvas-svg path[data-series='pressure']")).toHaveCount(1);
+  // Still playing: the chart arrived without the animation having to finish.
+  await expect(page.getByRole("button", { name: "Pause" })).toBeVisible();
+});
+
 test("two runs of the identical recipe produce the identical result hash (determinism)", async ({ page }) => {
   await page.goto("/");
   await openRecipeEditor(page);

--- a/web/src/features/shot/MetricStrip.test.tsx
+++ b/web/src/features/shot/MetricStrip.test.tsx
@@ -26,6 +26,21 @@ describe("MetricStrip", () => {
     expect(screen.getByText("target mass reached")).toBeInTheDocument(); // underscores -> spaces
   });
 
+  it("sets the stop reason in body type, not the numeric display face", () => {
+    // The strip's .value face is 27px Cormorant, sized for figures. Left in
+    // that face, "target mass reached" wrapped onto three lines and set the
+    // height of every other tile in the row; .metric-prose opts the one
+    // non-numeric tile out of it.
+    const result = makeShotResult({ termination: "target_mass_reached" });
+    const { container } = render(<MetricStrip result={result} />);
+
+    const prose = container.querySelectorAll(".metric-prose");
+    expect(prose).toHaveLength(1);
+    expect(prose[0]).toHaveTextContent("target mass reached");
+    // Every figure tile keeps the display face.
+    expect(container.querySelectorAll(".metric")).toHaveLength(7);
+  });
+
   it("replaces every underscore in the termination reason, not just the first", () => {
     const result = makeShotResult({ termination: "maximum_time_reached_safely" });
     render(<MetricStrip result={result} />);

--- a/web/src/features/shot/MetricStrip.tsx
+++ b/web/src/features/shot/MetricStrip.tsx
@@ -1,8 +1,22 @@
 import type { ShotResult } from "../../api/types";
 
-function Metric({ label, value, unit }: { label: string; value: string; unit?: string }) {
+function Metric({
+  label,
+  value,
+  unit,
+  // The strip's display face is sized for figures. A metric whose value is
+  // prose rather than a number (the stop reason) sets in body type instead --
+  // at 27 px Cormorant "target mass reached" wrapped onto three lines and
+  // stretched every other tile in the row to match.
+  prose = false,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+  prose?: boolean;
+}) {
   return (
-    <div className="metric">
+    <div className={prose ? "metric metric-prose" : "metric"}>
       <div className="label">{label}</div>
       <div className="value">
         {value}
@@ -22,7 +36,7 @@ export function MetricStrip({ result }: { result: ShotResult }) {
       <Metric label="TDS" value={result.tds_percent.toFixed(2)} unit="%" />
       <Metric label="Extraction" value={result.extraction_yield_percent.toFixed(2)} unit="%" />
       <Metric label="Brew ratio" value={`1:${result.brew_ratio.toFixed(2)}`} />
-      <Metric label="Stop" value={result.termination.replace(/_/g, " ")} />
+      <Metric label="Stop" value={result.termination.replace(/_/g, " ")} prose />
     </div>
   );
 }

--- a/web/src/features/shot/ShotWorkspace.tsx
+++ b/web/src/features/shot/ShotWorkspace.tsx
@@ -1,19 +1,25 @@
-import { Suspense, lazy, useState } from "react";
+import { useState } from "react";
 
 import type { Recipe, RecipeCatalogueEntry, ShotResult, ValidationIssue } from "../../api/types";
 import { preInfusionEnd } from "../../state/workspace";
 import { ComparisonTray } from "../comparison/ComparisonTray";
+import { ChartStack } from "./ChartStack";
 import { ControlRail } from "./ControlRail";
 import { DiagnosticsDrawer } from "./DiagnosticsDrawer";
 import { FlavorPanel } from "./FlavorPanel";
 import { MetricStrip } from "./MetricStrip";
 import { PuckView } from "./PuckView";
 
-// ChartStack now draws through AnalysisCanvas rather than recharts, so it no
-// longer carries that dependency's weight -- but it still only ever renders
-// once a shot has run, so a dynamic import keeps its own chunk out of what's
-// needed just to open the workbench and edit a recipe.
-const ChartStack = lazy(() => import("./ChartStack").then((mod) => ({ default: mod.ChartStack })));
+// ChartStack is imported statically. It used to be lazy to keep recharts out
+// of the initial bundle, but it now draws through AnalysisCanvas and its own
+// chunk had shrunk to ~3.6 kB -- far too little to be worth a Suspense
+// boundary here, because that boundary sat next to PuckView. A fresh run
+// auto-plays PuckView's transport, which drives setPlayhead from
+// requestAnimationFrame every frame for the whole shot; those default-priority
+// updates starve React's lower-priority retry of a suspended boundary, so the
+// charts stayed behind "Loading charts..." until the playback ended (29 s for
+// the baseline recipe) or the reader hit Pause. Rendering ChartStack
+// synchronously removes the boundary, and with it the starvation.
 
 interface Props {
   recipes: RecipeCatalogueEntry[];
@@ -84,15 +90,13 @@ export function ShotWorkspace({
               targetBeverageG={activeRecipe?.stop.target_beverage_g ?? null}
               cursorTimeSeconds={cursorTimeSeconds}
             />
-            <Suspense fallback={<p className="note" aria-live="polite">Loading charts...</p>}>
-              <ChartStack
-                result={active}
-                comparisons={comparisons}
-                preInfusionEnd={activeRecipe ? preInfusionEnd(activeRecipe) : undefined}
-                cursorTimeSeconds={cursorTimeSeconds}
-                onCursorChange={setCursorTimeSeconds}
-              />
-            </Suspense>
+            <ChartStack
+              result={active}
+              comparisons={comparisons}
+              preInfusionEnd={activeRecipe ? preInfusionEnd(activeRecipe) : undefined}
+              cursorTimeSeconds={cursorTimeSeconds}
+              onCursorChange={setCursorTimeSeconds}
+            />
             <ComparisonTray
               runs={pinned}
               activeId={active.manifest.run_id}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -283,6 +283,18 @@ button.tertiary:hover:not(:disabled), .button.tertiary:hover { background: rgba(
   margin-top: 6px;
 }
 .metric .unit { font-family: var(--font-body); font-size: 13px; color: var(--muted); margin-left: 4px; }
+/* A metric whose value is a word, not a figure (the stop reason). The display
+   face at 27px wrapped "target mass reached" onto three lines and set the
+   height of the whole strip; body type keeps the tile the size of its
+   neighbours. */
+.metric-prose { flex: 1 1 150px; }
+.metric-prose .value {
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.35;
+  margin-top: 9px;
+  color: var(--text);
+}
 
 .chart-card {
   background: var(--panel);
@@ -290,8 +302,15 @@ button.tertiary:hover:not(:disabled), .button.tertiary:hover { background: rgba(
   border-radius: var(--radius-md);
   padding: 13px 14px 6px;
   margin-bottom: 14px;
-  /* Audit #10: reserve the chart's settled height so mounting a result does
-     not reflow controls the user may be reaching for. */
+}
+/* Audit #10 reserved a chart's settled height so mounting a result does not
+   reflow controls the reader may be reaching for. That belongs on the cards
+   that actually hold a plot: every chart in the app now sizes its own plot
+   area (AnalysisCanvas's well, the sweep chart's ResponsiveContainer), while
+   the blanket rule left ~300px of dead space under the short cards that share
+   the surface -- the comparison tray, the sweep form, the calibration panel. */
+.chart-card.analysis-canvas,
+.chart-card.measured-comparison {
   min-height: 300px;
 }
 .chart-card h3 { margin: 0 0 6px; font-size: 12px; color: var(--muted); font-weight: 600; }


### PR DESCRIPTION
## Summary

ChartStack is now imported statically instead of lazily. This fixes a regression where the shot analysis charts remained hidden behind a "Loading charts..." message for the entire duration of the puck transport animation (up to 29 seconds) because React's lower-priority Suspense retry was starved by high-priority state updates from the transport's requestAnimationFrame loop.

## Changes

- **ShotWorkspace.tsx**: Removed lazy import and Suspense boundary around ChartStack. The component is now imported statically and rendered directly. The bundle size savings from lazy loading (~3.6 kB) no longer justify the Suspense boundary overhead given the starvation issue.

- **MetricStrip.tsx & styles.css**: Added `prose` styling variant for the "Stop" metric. The stop reason (e.g., "target mass reached") is prose text rather than a numeric figure. At 27px in the display face (Cormorant), it wrapped onto three lines and stretched all other tiles in the metric strip. The new `.metric-prose` class uses body type (14px) to keep the tile proportional to its neighbors.

- **styles.css**: Refined the min-height rule from Audit #10. The 300px reservation now applies only to `.analysis-canvas` and `.measured-comparison` cards that actually contain plots. Other cards (comparison tray, sweep form, calibration panel) no longer reserve dead space.

- **dashboard.spec.ts**: Added regression test that verifies the charts appear while the puck transport is still playing. The test confirms that the analysis canvas, pressure series, and absence of "Loading charts..." text all occur before the animation completes.

## Implementation Details

The starvation occurred because:
1. A completed shot auto-plays PuckView's transport animation
2. The transport calls `setPlayhead` from requestAnimationFrame every frame (default priority)
3. These high-priority updates starved React's lower-priority retry mechanism for the Suspense boundary
4. The boundary sat next to PuckView, making the starvation unavoidable without removing the boundary

Rendering ChartStack synchronously eliminates the boundary and the starvation entirely. The component's reduced bundle footprint (now that it uses AnalysisCanvas instead of recharts) makes the synchronous approach acceptable.

https://claude.ai/code/session_01MXSjcM9ZhtN3MJnCWfsCNs